### PR TITLE
WinMM: fix random crashing when shutting down

### DIFF
--- a/winmm/soloud_winmm.cpp
+++ b/winmm/soloud_winmm.cpp
@@ -77,11 +77,11 @@ namespace SoLoud
         if (0 == aSoloud->mBackendData)
             return;
         SoLoudWinMMData *data = static_cast<SoLoudWinMMData*>(aSoloud->mBackendData);
-        waveOutReset(data->waveOut);
         data->audioProcessingDone = true;
         SetEvent(data->audioEvent);
         while (data->threadRunning)
             Sleep(10);
+        waveOutReset(data->waveOut);
         for (int i=0;i<BUFFER_COUNT;++i) {
             waveOutUnprepareHeader(data->waveOut, &data->header[i], sizeof(WAVEHDR));
             if (0 != data->sampleBuffer[i])


### PR DESCRIPTION
never experienced any crashing with msvc but luckily I tried also with mingw. 
if you call waveOutReset before killing the thread, audio processing starts all over again because the thread is still running. then when you try to delete those sample buffers, audio driver might still be using them -> crash. kinda stupid mistake left by me :)
