### PR TITLE
Added -fPIC when building gmake + gcc. Fixes #115

### DIFF
--- a/build/genie.lua
+++ b/build/genie.lua
@@ -328,7 +328,10 @@ solution "SoLoud"
 	--       doesn't do this well on it's own and is recommended to setup this
 	--       manually. See https://github.com/bkaradzic/bx/blob/master/scripts/toolchain.lua
 	configuration { "gmake" }
-		buildoptions { "-msse4.1" }
+		buildoptions { 
+			"-msse4.1", 
+			"-fPIC"
+		}
 
     configuration {}
 


### PR DESCRIPTION
Seems that it's a problem when linking the shared objects. Not completely sure why it's not been hit before now, unless you've been building with an older GCC when doing Linux builds? Anyhow, tested with GCC 4.8.2 on my laptop, seems to work a'ok.