### PR TITLE
OpenAL fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build/
 *.out
 *.gz
 *.toc
+*.o
 incoming/
 experiments/
 doc/*.html

--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ r-lyeh https://github.com/r-lyeh
 Colden Cullen https://github.com/ColdenCullen
 Cosku Bas cosku.bas@gmail.com
 Neil Richardson https://github.com/neilogd
+Petri Häkkinen

--- a/include/soloud_vic.h
+++ b/include/soloud_vic.h
@@ -1,0 +1,108 @@
+/*
+SoLoud audio engine
+Copyright (c) 2015 Jari Komppa
+
+VIC 6560/6561 sound chip emulator
+Copyright (c) 2015 Petri Hakkinen
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+   1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+   3. This notice may not be removed or altered from any source
+   distribution.
+*/
+
+#ifndef SOLOUD_VIC_H
+#define SOLOUD_VIC_H
+
+#include "soloud.h"
+
+/*
+A very bare bones emulator for Commodore VIC-20 sound chip. Supports both PAL and NTSC models.
+Bass, alto and soprano should be quite close to original vic, noise probably not so.
+
+The first three channels (bass, alto and soprano) are square waveform generators with 7-bit frequency.
+The highest bit of each oscillator register switches the oscillator on/off.
+The fourth oscillator generates a noise waveform.
+
+VIC-20 does not have per channel volume control, only global volume,
+which you can change by setting audio source's volume.
+
+To get that authentic moldy VIC-20 sound, the audio source should be coupled with a biquad resonant filter
+with the following params: type = LOWPASS, sample rate = 44100, frequency = 1500, resonance = 2.0.
+*/
+
+namespace SoLoud
+{
+	class Vic;
+
+	class VicInstance : public AudioSourceInstance
+	{
+	public:
+		VicInstance(Vic *aParent);
+		~VicInstance();
+
+		virtual void getAudio(float *aBuffer, unsigned int aSamples);
+		virtual bool hasEnded();
+
+	private:
+		Vic*		m_parent;
+		int			m_phase[4];
+		int			m_noisePos;
+	};
+
+	class Vic : public AudioSource
+	{
+	public:
+		// VIC model
+		enum
+		{
+			PAL	= 0,
+			NTSC,
+		};
+
+		// VIC sound registers
+		enum
+		{
+			BASS = 0,
+			ALTO,
+			SOPRANO,
+			NOISE,
+			MAX_REGS
+		};
+
+		Vic();
+		virtual ~Vic();
+		
+		void setModel(int model);
+		int getModel() const;
+
+		void setRegister(int reg, unsigned char value) 		{ m_regs[reg] = value; }
+		unsigned char getRegister(int reg) const			{ return m_regs[reg]; }
+
+		virtual AudioSourceInstance *createInstance();
+
+	private:
+		friend class VicInstance;
+
+		int				m_model;
+		float			m_clocks[4];		// base clock frequencies for oscillators, dependent on VIC model
+		unsigned char	m_regs[MAX_REGS];		
+		unsigned char 	m_noise[8192];
+	};
+};
+
+#endif

--- a/src/audiosource/vic/soloud_vic.cpp
+++ b/src/audiosource/vic/soloud_vic.cpp
@@ -1,0 +1,152 @@
+/*
+SoLoud audio engine
+Copyright (c) 2015 Jari Komppa
+
+VIC 6560/6561 sound chip emulator
+Copyright (c) 2015 Petri Hakkinen
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+   1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+
+   2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+   3. This notice may not be removed or altered from any source
+   distribution.
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include "soloud_vic.h"
+
+namespace SoLoud
+{
+
+	VicInstance::VicInstance(Vic *aParent)
+	{
+		m_parent = aParent;
+
+		for(int i = 0; i < 4; i++)
+			m_phase[i] = 0;
+
+		m_noisePos = 0;
+	}
+
+	VicInstance::~VicInstance()
+	{
+	}
+
+	void VicInstance::getAudio(float *aBuffer, unsigned int aSamples)
+	{
+		for(int i = 0; i < aSamples; i++)
+		{
+			float s = 0.0f;
+
+			// square waves
+			for(int v = 0; v < 3; v++)
+			{
+				unsigned char reg = m_parent->getRegister(v);
+				if(reg >= 128)
+				{
+					s += (m_phase[v] < 32768 ? 0.5f : -0.5f);
+
+					float freq = m_parent->m_clocks[v] / (float)(reg < 255 ? 255 - reg : 1);
+					m_phase[v] += (freq * 65536.0f / 44100.0f + 0.5f);
+					m_phase[v] &= 65535;
+				}
+			}
+
+			// noise
+			unsigned char reg = m_parent->getRegister(3);
+			if(reg >= 128)
+			{
+				s += (float)m_parent->m_noise[m_noisePos] / 255.0f - 0.5f;
+
+				float freq = m_parent->m_clocks[3] / (float)(reg < 255 ? 255 - reg : 1);
+				m_phase[3] += (freq * 65536.0f / 44100.0f + 0.5f);
+
+				if(m_phase[3] >= 32768)
+				{
+					m_noisePos = (m_noisePos + 1) & 8191;
+					m_phase[3] &= 32767;
+				}
+			}
+
+			aBuffer[i] = s / 4.0f;
+		}
+	}
+
+	bool VicInstance::hasEnded()
+	{
+		return false;
+	}
+
+	Vic::Vic()
+	{
+		mBaseSamplerate = 44100;
+		setModel(PAL);
+
+		for(int i = 0; i < MAX_REGS; i++)
+			m_regs[i] = 0;
+
+		// Galois LFSR (source: https://en.wikipedia.org/wiki/Linear_feedback_shift_register)
+	    unsigned short lfsr = 0xACE1u;
+		for(int i = 0; i < 8192; i++)
+		{
+		    unsigned lsb = lfsr & 1;
+		    lfsr >>= 1;
+		    lfsr ^= (-lsb) & 0xB400u;
+		    m_noise[i] = (lfsr & 0xff) ^ (lfsr >> 8);
+		}
+	}
+
+	Vic::~Vic()
+	{
+		stop();
+	}
+
+	void Vic::setModel(int model)
+	{
+		m_model = model;
+
+		switch(model)
+		{
+		case PAL:
+			m_clocks[0] = 4329.0f;
+			m_clocks[1] = 8659.0f;
+			m_clocks[2] = 17320.0f;
+			m_clocks[3] = 34640.0f;
+			break;
+
+		case NTSC:
+			m_clocks[0] = 3995.0f;
+			m_clocks[1] = 7990.0f;
+			m_clocks[2] = 15980.0f;
+			m_clocks[3] = 31960.0f;
+			break;
+		}
+	}
+
+	int Vic::getModel() const
+	{
+		return m_model;
+	}
+
+	AudioSourceInstance * Vic::createInstance() 
+	{
+		return new VicInstance(this);
+	}
+
+};

--- a/src/backend/openal/soloud_openal_dll.c
+++ b/src/backend/openal/soloud_openal_dll.c
@@ -37,27 +37,59 @@ freely, subject to the following restrictions:
 #define WINDOWS_VERSION
 #endif
 
+#ifdef SOLOUD_STATIC_OPENAL
+
+// statically linked OpenAL 
+int dll_al_found() { return 1; }
+ALCdevice* dll_alc_OpenDevice(const ALCchar *devicename) { return alcOpenDevice(devicename); }
+void dll_alc_CloseDevice(ALCdevice *device) { alcCloseDevice(device); }
+ALCcontext* dll_alc_CreateContext(ALCdevice *device, const ALCint* attrlist) { return alcCreateContext(device, attrlist); }
+void dll_alc_DestroyContext(ALCcontext *context) { return alcDestroyContext(context); }
+ALCboolean dll_alc_MakeContextCurrent(ALCcontext *context) { return alcMakeContextCurrent(context); }
+void dll_al_GetSourcei(ALuint source, ALenum param, ALint *value) { alGetSourcei(source, param, value); }
+void dll_al_SourceQueueBuffers(ALuint source, ALsizei nb, const ALuint *buffers) { alSourceQueueBuffers(source, nb, buffers); }
+void dll_al_SourceUnqueueBuffers(ALuint source, ALsizei nb, ALuint *buffers) { alSourceUnqueueBuffers(source, nb, buffers); }
+void dll_al_BufferData(ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq) { alBufferData(buffer, format, data, size, freq); }
+void dll_al_SourcePlay(ALuint source) { alSourcePlay(source); }
+void dll_al_SourceStop(ALuint source) { alSourceStop(source); }
+void dll_al_GenBuffers(ALsizei n, ALuint *buffers) { alGenBuffers(n, buffers); }
+void dll_al_DeleteBuffers(ALsizei n, ALuint *buffers) { alDeleteBuffers(n, buffers); }
+void dll_al_GenSources(ALsizei n, ALuint *sources) { alGenSources(n, sources); }
+void dll_al_DeleteSources(ALsizei n, ALuint *sources) { alDeleteSources(n, sources); }
+
+#else
+
 typedef ALCdevice* (*alc_OpenDevice)(const ALCchar *devicename);
+typedef void (*alc_CloseDevice)(ALCdevice *device);
 typedef ALCcontext* (*alc_CreateContext)(ALCdevice *device, const ALCint* attrlist);
+typedef void (*alc_DestroyContext)(ALCcontext *context);
 typedef ALCboolean (*alc_MakeContextCurrent)(ALCcontext *context);
 typedef void (*al_GetSourcei)(ALuint source, ALenum param, ALint *value);
 typedef void (*al_SourceQueueBuffers)(ALuint source, ALsizei nb, const ALuint *buffers);
 typedef void (*al_SourceUnqueueBuffers)(ALuint source, ALsizei nb, ALuint *buffers);
 typedef void (*al_BufferData)(ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq);
 typedef void (*al_SourcePlay)(ALuint source);
+typedef void (*al_SourceStop)(ALuint source);
 typedef void (*al_GenBuffers)(ALsizei n, ALuint *buffers);
+typedef void (*al_DeleteBuffers)(ALsizei n, ALuint *buffers);
 typedef void (*al_GenSources)(ALsizei n, ALuint *sources);
+typedef void (*al_DeleteSources)(ALsizei n, ALuint *sources);
 
 static alc_OpenDevice dAlcOpenDevice;
+static alc_CloseDevice dAlcCloseDevice;
 static alc_CreateContext dAlcCreateContext;
+static alc_DestroyContext dAlcDestroyContext;
 static alc_MakeContextCurrent dAlcMakeContextCurrent;
 static al_GetSourcei dAlGetSourcei;
 static al_SourceQueueBuffers dAlSourceQueueBuffers;
 static al_SourceUnqueueBuffers dAlSourceUnqueueBuffers;
 static al_BufferData dAlBufferData;
 static al_SourcePlay dAlSourcePlay;
+static al_SourceStop dAlSourceStop;
 static al_GenBuffers dAlGenBuffers;
+static al_DeleteBuffers dAlDeleteBuffers;
 static al_GenSources dAlGenSources;
+static al_DeleteSources dAlDeleteSources;
 
 #ifdef WINDOWS_VERSION
 #include <windows.h>
@@ -109,26 +141,36 @@ static int load_dll()
     if (dll)
     {
         dAlcOpenDevice = (alc_OpenDevice)getDllProc(dll, "alcOpenDevice");
+        dAlcCloseDevice = (alc_CloseDevice)getDllProc(dll, "alcCloseDevice");
         dAlcCreateContext = (alc_CreateContext)getDllProc(dll, "alcCreateContext");
+        dAlcDestroyContext = (alc_DestroyContext)getDllProc(dll, "alcDestroyContext");
         dAlcMakeContextCurrent = (alc_MakeContextCurrent)getDllProc(dll, "alcMakeContextCurrent");
         dAlGetSourcei = (al_GetSourcei)getDllProc(dll, "alGetSourcei");
         dAlSourceQueueBuffers = (al_SourceQueueBuffers)getDllProc(dll, "alSourceQueueBuffers");
         dAlSourceUnqueueBuffers = (al_SourceUnqueueBuffers)getDllProc(dll, "alSourceUnqueueBuffers");
         dAlBufferData = (al_BufferData)getDllProc(dll, "alBufferData");
         dAlSourcePlay = (al_SourcePlay)getDllProc(dll, "alSourcePlay");
+        dAlSourceStop = (al_SourceStop)getDllProc(dll, "alSourceStop");
         dAlGenBuffers = (al_GenBuffers)getDllProc(dll, "alGenBuffers");
+        dAlDeleteBuffers = (al_GenBuffers)getDllProc(dll, "alDeleteBuffers");
         dAlGenSources = (al_GenSources)getDllProc(dll, "alGenSources");
+        dAlDeleteSources = (al_GenSources)getDllProc(dll, "alDeleteSources");
 
         if (dAlcOpenDevice &&
+        	dAlcCloseDevice &&
 			dAlcCreateContext &&
+			dAlcDestroyContext &&
 			dAlcMakeContextCurrent &&
             dAlGetSourcei &&
 			dAlSourceQueueBuffers &&
             dAlSourceUnqueueBuffers &&
 			dAlBufferData && 
 			dAlSourcePlay &&
+			dAlSourceStop &&
             dAlGenBuffers &&
-			dAlGenSources)
+            dAlDeleteBuffers &&
+			dAlGenSources &&
+			dAlDeleteSources)
         {
             return 1;
         }
@@ -149,11 +191,23 @@ ALCdevice* dll_alc_OpenDevice(const ALCchar *devicename)
 	return NULL;
 }
 
+void dll_alc_CloseDevice(ALCdevice *device)
+{
+	if (load_dll())
+		return dAlcCloseDevice(device);
+}
+
 ALCcontext* dll_alc_CreateContext(ALCdevice *device, const ALCint* attrlist)
 {
 	if (load_dll())
 		return dAlcCreateContext(device, attrlist);
 	return NULL;
+}
+
+void dll_alc_DestroyContext(ALCcontext *context)
+{
+	if (load_dll())
+		return dAlcDestroyContext(context);
 }
 
 ALCboolean dll_alc_MakeContextCurrent(ALCcontext *context)
@@ -193,10 +247,22 @@ void dll_al_SourcePlay(ALuint source)
 		dAlSourcePlay(source);
 }
 
+void dll_al_SourceStop(ALuint source)
+{
+	if (load_dll())
+		dAlSourceStop(source);
+}
+
 void dll_al_GenBuffers(ALsizei n, ALuint *buffers)
 {
 	if (load_dll())
 		dAlGenBuffers(n, buffers);
+}
+
+void dll_al_DeleteBuffers(ALsizei n, ALuint *buffers)
+{
+	if (load_dll())
+		dAlDeleteBuffers(n, buffers);
 }
 
 void dll_al_GenSources(ALsizei n, ALuint *sources)
@@ -204,3 +270,11 @@ void dll_al_GenSources(ALsizei n, ALuint *sources)
 	if (load_dll())
 		dAlGenSources(n, sources);
 }
+
+void dll_al_DeleteSources(ALsizei n, ALuint *sources)
+{
+	if (load_dll())
+		dAlDeleteSources(n, sources);
+}
+
+#endif


### PR DESCRIPTION
Fixed OpenAL deinitialization. Added missing calls to alcDestroyContext, alcCloseDevice etc.

Made buffer size configurable. Buffer size was previously hardcoded to 4096 which generated a lot of latency. Now the buffer size passed to soloud init is used.

Added optional static linking to OpenAL library (SOLOUD_STATIC_OPENAL define). Useful for projects that don't want to ship many DLLs (for example, I have a statically compiled version of Soft AL in my code base). Take it or leave it :-)