### PR TITLE
Fixed update3dVoices() accessing incorrect location in m3dData.

### DIFF
--- a/src/core/soloud_core_3d.cpp
+++ b/src/core/soloud_core_3d.cpp
@@ -212,7 +212,7 @@ namespace SoLoud
 
 		for (i = 0; i < (signed)aVoiceCount; i++)
 		{
-			AudioSourceInstance3dData * v = &m3dData[i];
+			AudioSourceInstance3dData * v = &m3dData[aVoiceArray[i]];
 
 			float vol = 1;
 


### PR DESCRIPTION
When non-3d sounds are played before 3d sounds, the 3d sounds access incorrect location in m3dData.