### PR TITLE
Fixed warnings for Clang, Compile Error on FreeBSD/PS4, Ignore List

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,12 +22,16 @@ doc/*.mobi
 doc/*.epub
 bin/audio/
 bin/
+lib/*.ilk
+lib/*.lib
+lib/*.dll
 out/
 *.pyc
 *.exp
 doc/xelatex_output.txt
 doc/kindlegen_output.txt
 *.idb
+*.pdb
 doc/20*
 glue/soloud*
 scripts/soloud_codegen.py

--- a/src/audiosource/speech/tts.cpp
+++ b/src/audiosource/speech/tts.cpp
@@ -872,6 +872,7 @@ static int leftmatch(
 	{
 		/* First check for simple text or space */
 		if (isalpha(*pat) || *pat == '\'' || *pat == ' ')
+		{
 			if (*pat != *text)
 				return 0;
 			else
@@ -879,62 +880,63 @@ static int leftmatch(
 				text--;
 				continue;
 			}
+		}
 
-			switch (*pat)
-			{
+		switch (*pat)
+		{
 
-			case '#':                   /* One or more vowels */
+		case '#':                   /* One or more vowels */
 
-				if (!isvowel(*text))
-					return 0;
-
-				text--;
-
-				while (isvowel(*text))
-					text--;
-
-				break;
-
-			case ':':                   /* Zero or more consonants */
-				while (isconsonant(*text))
-					text--;
-
-				break;
-
-			case '^':                   /* One consonant */
-				if (!isconsonant(*text))
-					return 0;
-
-				text--;
-
-				break;
-
-			case '.':                   /* B, D, V, G, J, L, M, N, R, W, Z */
-				if (*text != 'B' && *text != 'D' && *text != 'V'
-					&& *text != 'G' && *text != 'J' && *text != 'L'
-					&& *text != 'M' && *text != 'N' && *text != 'R'
-					&& *text != 'W' && *text != 'Z')
-					return 0;
-
-				text--;
-
-				break;
-
-			case '+':                   /* E, I or Y (front vowel) */
-				if (*text != 'E' && *text != 'I' && *text != 'Y')
-					return 0;
-
-				text--;
-
-				break;
-
-			case '%':
-
-			default:
-				fprintf(stderr, "Bad char in left rule: '%c'\n", *pat);
-
+			if (!isvowel(*text))
 				return 0;
-			}
+
+			text--;
+
+			while (isvowel(*text))
+				text--;
+
+			break;
+
+		case ':':                   /* Zero or more consonants */
+			while (isconsonant(*text))
+				text--;
+
+			break;
+
+		case '^':                   /* One consonant */
+			if (!isconsonant(*text))
+				return 0;
+
+			text--;
+
+			break;
+
+		case '.':                   /* B, D, V, G, J, L, M, N, R, W, Z */
+			if (*text != 'B' && *text != 'D' && *text != 'V'
+				&& *text != 'G' && *text != 'J' && *text != 'L'
+				&& *text != 'M' && *text != 'N' && *text != 'R'
+				&& *text != 'W' && *text != 'Z')
+				return 0;
+
+			text--;
+
+			break;
+
+		case '+':                   /* E, I or Y (front vowel) */
+			if (*text != 'E' && *text != 'I' && *text != 'Y')
+				return 0;
+
+			text--;
+
+			break;
+
+		case '%':
+
+		default:
+			fprintf(stderr, "Bad char in left rule: '%c'\n", *pat);
+
+			return 0;
+		}
 	}
 
 	return 1;
@@ -959,6 +961,7 @@ static int rightmatch(
 	{
 		/* First check for simple text or space */
 		if (isalpha(*pat) || *pat == '\'' || *pat == ' ')
+		{
 			if (*pat != *text)
 				return 0;
 			else
@@ -966,111 +969,112 @@ static int rightmatch(
 				text++;
 				continue;
 			}
+		}
 
-			switch (*pat)
+		switch (*pat)
+		{
+
+		case '#':                   /* One or more vowels */
+
+			if (!isvowel(*text))
+				return 0;
+
+			text++;
+
+			while (isvowel(*text))
+				text++;
+
+			break;
+
+		case ':':                   /* Zero or more consonants */
+			while (isconsonant(*text))
+				text++;
+
+			break;
+
+		case '^':                   /* One consonant */
+			if (!isconsonant(*text))
+				return 0;
+
+			text++;
+
+			break;
+
+		case '.':                   /* B, D, V, G, J, L, M, N, R, W, Z */
+			if (*text != 'B' && *text != 'D' && *text != 'V'
+				&& *text != 'G' && *text != 'J' && *text != 'L'
+				&& *text != 'M' && *text != 'N' && *text != 'R'
+				&& *text != 'W' && *text != 'Z')
+				return 0;
+
+			text++;
+
+			break;
+
+		case '+':                   /* E, I or Y (front vowel) */
+			if (*text != 'E' && *text != 'I' && *text != 'Y')
+				return 0;
+
+			text++;
+
+			break;
+
+		case '%':                   /* ER, E, ES, ED, ING, ELY (a suffix) */
+			if (*text == 'E')
 			{
-
-			case '#':                   /* One or more vowels */
-
-				if (!isvowel(*text))
-					return 0;
-
 				text++;
 
-				while (isvowel(*text))
-					text++;
-
-				break;
-
-			case ':':                   /* Zero or more consonants */
-				while (isconsonant(*text))
-					text++;
-
-				break;
-
-			case '^':                   /* One consonant */
-				if (!isconsonant(*text))
-					return 0;
-
-				text++;
-
-				break;
-
-			case '.':                   /* B, D, V, G, J, L, M, N, R, W, Z */
-				if (*text != 'B' && *text != 'D' && *text != 'V'
-					&& *text != 'G' && *text != 'J' && *text != 'L'
-					&& *text != 'M' && *text != 'N' && *text != 'R'
-					&& *text != 'W' && *text != 'Z')
-					return 0;
-
-				text++;
-
-				break;
-
-			case '+':                   /* E, I or Y (front vowel) */
-				if (*text != 'E' && *text != 'I' && *text != 'Y')
-					return 0;
-
-				text++;
-
-				break;
-
-			case '%':                   /* ER, E, ES, ED, ING, ELY (a suffix) */
-				if (*text == 'E')
+				if (*text == 'L')
 				{
 					text++;
 
-					if (*text == 'L')
+					if (*text == 'Y')
 					{
 						text++;
-
-						if (*text == 'Y')
-						{
-							text++;
-							break;
-						}
-
-						else
-						{
-							text--;               /* Don't gobble L */
-							break;
-						}
+						break;
 					}
 
 					else
-						if (*text == 'R' || *text == 'S' || *text == 'D')
-							text++;
-
-					break;
+					{
+						text--;               /* Don't gobble L */
+						break;
+					}
 				}
 
 				else
-					if (*text == 'I')
+					if (*text == 'R' || *text == 'S' || *text == 'D')
+						text++;
+
+				break;
+			}
+
+			else
+				if (*text == 'I')
+				{
+					text++;
+
+					if (*text == 'N')
 					{
 						text++;
 
-						if (*text == 'N')
+						if (*text == 'G')
 						{
 							text++;
-
-							if (*text == 'G')
-							{
-								text++;
-								break;
-							}
+							break;
 						}
-
-						return 0;
 					}
 
-					else
-						return 0;
+					return 0;
+				}
 
-			default:
-				fprintf(stderr, "Bad char in right rule:'%c'\n", *pat);
+				else
+					return 0;
 
-				return 0;
-			}
+		default:
+			fprintf(stderr, "Bad char in right rule:'%c'\n", *pat);
+
+			return 0;
+		}
 	}
 
 	return 1;

--- a/src/audiosource/tedsid/ted.cpp
+++ b/src/audiosource/tedsid/ted.cpp
@@ -88,7 +88,7 @@ void TED::writeSoundReg(unsigned int reg, unsigned char value)
 			setFreq(1, Freq2);
 			break;
 		case 3:
-			if (DAStatus = value & 0x80) {
+			if ((DAStatus = value & 0x80)) {
 				FlipFlop[0] = 1;
 				FlipFlop[1] = 1;
 				oscCount[0] = OscReload[0];

--- a/src/audiosource/wav/stb_vorbis.c
+++ b/src/audiosource/wav/stb_vorbis.c
@@ -555,7 +555,7 @@ enum STBVorbisError
 #include <string.h>
 #include <assert.h>
 #include <math.h>
-#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh))
+#if !(defined(__APPLE__) || defined(MACOSX) || defined(macintosh) || defined(Macintosh) || defined(__FreeBSD__))
 #include <malloc.h>
 #endif
 #else


### PR DESCRIPTION
Minor fixes.
- Fixes Clang warnings (adding missing braces, two blocks were misleading space-offseted)
- Fixed stb_vorbis compile error for PS4 running on FreeBSD, will submit PR upstream to nothings
- Added Ignore List for Visual Studio output