### PR TITLE
updated the libopenmpt dll wrapper to work with MinGW as well

### DIFF
--- a/src/audiosource/openmpt/soloud_openmpt_dll.c
+++ b/src/audiosource/openmpt/soloud_openmpt_dll.c
@@ -22,8 +22,10 @@ freely, subject to the following restrictions:
    distribution.
 */
 #include <stdlib.h>
-#if defined(_MSC_VER)
+#if defined(_WIN32)||defined(_WIN64)
 #define WINDOWS_VERSION
+#endif // __WINDOWS__
+#if defined(_MSC_VER)
 #include "SDL.h"
 #else
 #include "SDL/SDL.h"


### PR DESCRIPTION
hello,
this file give's error when you want to compile it with MinGW GCC
i've fixed it and it work's