### PR TITLE
Removed SDL includes from soloud_openmpt_dll.c

### DIFF
--- a/src/audiosource/openmpt/soloud_openmpt_dll.c
+++ b/src/audiosource/openmpt/soloud_openmpt_dll.c
@@ -25,11 +25,6 @@ freely, subject to the following restrictions:
 #if defined(_WIN32)||defined(_WIN64)
 #define WINDOWS_VERSION
 #endif // __WINDOWS__
-#if defined(_MSC_VER)
-#include "SDL.h"
-#else
-#include "SDL/SDL.h"
-#endif
 #include <math.h>
 
 typedef void * (*dll_openmpt_module_create_from_memory)(const void * filedata, size_t filesize, void *logfunc, void * user, void * ctls);


### PR DESCRIPTION
Doesn't seem to be used, so removed (build errors in my projects)