### PR TITLE
Add Soloud::playBackground to play sounds / music without panning 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,3 +16,4 @@ Neil Richardson https://github.com/neilogd
 Petri Häkkinen
 Omar Cornut
 amir ramezani <amir.ramezani1370@gmail.com> http://shaberoshan.ir
+Luke San Antonio Bialecki lukesanantonio@gmail.com

--- a/include/soloud.h
+++ b/include/soloud.h
@@ -182,6 +182,8 @@ namespace SoLoud
 		handle play3d(AudioSource &aSound, float aPosX, float aPosY, float aPosZ, float aVelX = 0.0f, float aVelY = 0.0f, float aVelZ = 0.0f, float aVolume = 1.0f, bool aPaused = 0, unsigned int aBus = 0);
 		// Start playing a 3d audio source, delayed in relation to other sounds called via this function.
 		handle play3dClocked(time aSoundTime, AudioSource &aSound, float aPosX, float aPosY, float aPosZ, float aVelX = 0.0f, float aVelY = 0.0f, float aVelZ = 0.0f, float aVolume = 1.0f, unsigned int aBus = 0);
+		// Start playing a sound without any panning. It will be played at full volume.
+		handle playBackground(AudioSource &aSound, float aVolume = -1.0f, bool aPaused = 0, unsigned int aBus = 0);
 
 		// Seek the audio stream to certain point in time. Some streams can't seek backwards. Relative play speed affects time.
 		void seek(handle aVoiceHandle, time aSeconds);

--- a/src/core/soloud_core_basicops.cpp
+++ b/src/core/soloud_core_basicops.cpp
@@ -134,6 +134,13 @@ namespace SoLoud
 		return h;
 	}
 
+	handle Soloud::playBackground(AudioSource &aSound, float aVolume, bool aPaused, unsigned int aBus)
+	{
+		handle h = play(aSound, aVolume, 0.0f, aPaused, aBus);
+		setPanAbsolute(h, 1.0f, 1.0f);
+		return h;
+	}
+
 	void Soloud::seek(handle aVoiceHandle, time aSeconds)
 	{
 		FOR_ALL_VOICES_PRE


### PR DESCRIPTION
I noticed that when using SoLoud, music played in my game at a lower volume then many other programs (VLC, mplayer, etc). After some investigation, I found the 2D panning code was playing the music at about 71% volume in each ear because a pan value of 0.0 means it is equally between both ears. This behaviour wasn't clear to me from the documentation.

This function just overrides the volumes calculated with the pan value. What do you think?