### PR TITLE
Removed file hack need for stb_vorbis

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Petri Häkkinen
 Omar Cornut
 amir ramezani <amir.ramezani1370@gmail.com> http://shaberoshan.ir
 Luke San Antonio Bialecki lukesanantonio@gmail.com
+Eduardo Doria Lima https://github.com/eduardodoria

--- a/include/soloud_wav.h
+++ b/include/soloud_wav.h
@@ -48,7 +48,7 @@ namespace SoLoud
 	class Wav : public AudioSource
 	{
 		result loadwav(File *aReader);
-		result loadogg(stb_vorbis *aVorbis);
+		result loadogg(File *aReader);
 		result testAndLoadFile(File *aReader);
 	public:
 		float *mData;

--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -249,11 +249,24 @@ namespace SoLoud
 		return 0;
 	}
 
-	result Wav::loadogg(stb_vorbis *aVorbis)
+	result Wav::loadogg(File *aReader)
 	{
-        stb_vorbis_info info = stb_vorbis_get_info(aVorbis);
+		aReader->seek(0);
+		MemoryFile *memoryFile = new MemoryFile();
+		memoryFile->openFileToMem(aReader);
+
+		int e = 0;
+		stb_vorbis *vorbis = 0;
+		vorbis = stb_vorbis_open_memory(memoryFile->getMemPtr(), memoryFile->length(), &e, 0);
+
+		if (0 == vorbis)
+		{
+			return FILE_LOAD_FAILED;
+		}
+
+        stb_vorbis_info info = stb_vorbis_get_info(vorbis);
 		mBaseSamplerate = (float)info.sample_rate;
-        int samples = stb_vorbis_stream_length_in_samples(aVorbis);
+        int samples = stb_vorbis_stream_length_in_samples(vorbis);
 
 		int readchannels = 1;
 		if (info.channels > 1)
@@ -267,7 +280,7 @@ namespace SoLoud
 		while(1)
 		{
 			float **outputs;
-            int n = stb_vorbis_get_frame_float(aVorbis, NULL, &outputs);
+            int n = stb_vorbis_get_frame_float(vorbis, NULL, &outputs);
 			if (n == 0)
             {
 				break;
@@ -283,7 +296,7 @@ namespace SoLoud
 			}
 			samples += n;
 		}
-        stb_vorbis_close(aVorbis);
+        stb_vorbis_close(vorbis);
 
 		return 0;
 	}
@@ -296,16 +309,8 @@ namespace SoLoud
         int tag = aReader->read32();
 		if (tag == MAKEDWORD('O','g','g','S')) 
         {
-		 	aReader->seek(0);
-			int e = 0;
-			stb_vorbis *v = 0;
-			v = stb_vorbis_open_file((Soloud_Filehack*)aReader, 0, &e, 0);
+			return loadogg(aReader);
 
-			if (0 != v)
-            {
-				return loadogg(v);
-            }
-			return FILE_LOAD_FAILED;
 		} 
         else if (tag == MAKEDWORD('R','I','F','F')) 
         {

--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -252,12 +252,12 @@ namespace SoLoud
 	result Wav::loadogg(File *aReader)
 	{
 		aReader->seek(0);
-        MemoryFile memoryFile;
-        memoryFile.openFileToMem(aReader);
-        
-        int e = 0;
-        stb_vorbis *vorbis = 0;
-        vorbis = stb_vorbis_open_memory(memoryFile.getMemPtr(), memoryFile.length(), &e, 0);
+		MemoryFile memoryFile;
+		memoryFile.openFileToMem(aReader);
+		
+		int e = 0;
+		stb_vorbis *vorbis = 0;
+		vorbis = stb_vorbis_open_memory(memoryFile.getMemPtr(), memoryFile.length(), &e, 0);
 
 		if (0 == vorbis)
 		{

--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -252,12 +252,12 @@ namespace SoLoud
 	result Wav::loadogg(File *aReader)
 	{
 		aReader->seek(0);
-		MemoryFile *memoryFile = new MemoryFile();
-		memoryFile->openFileToMem(aReader);
-
-		int e = 0;
-		stb_vorbis *vorbis = 0;
-		vorbis = stb_vorbis_open_memory(memoryFile->getMemPtr(), memoryFile->length(), &e, 0);
+        MemoryFile memoryFile;
+        memoryFile.openFileToMem(aReader);
+        
+        int e = 0;
+        stb_vorbis *vorbis = 0;
+        vorbis = stb_vorbis_open_memory(memoryFile.getMemPtr(), memoryFile.length(), &e, 0);
 
 		if (0 == vorbis)
 		{

--- a/src/audiosource/wav/stb_vorbis.c
+++ b/src/audiosource/wav/stb_vorbis.c
@@ -70,8 +70,6 @@
 #include <stdio.h>
 #endif
 
-#include "soloud_file_hack_on.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
Removed soloud_file_hack_on.h need for stb_vorbis.c. Instead of using stb_vorbis_open_file(…) to open file handle, using stb_vorbis_open_memory(…) to open from memory.