### PR TITLE
Build error fix, re-add file hack to stb_vorbis

### DIFF
--- a/src/audiosource/wav/stb_vorbis.c
+++ b/src/audiosource/wav/stb_vorbis.c
@@ -70,6 +70,8 @@
 #include <stdio.h>
 #endif
 
+#include "soloud_file_hack_on.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -5395,3 +5397,5 @@ int stb_vorbis_get_samples_float(stb_vorbis *f, int channels, float **buffer, in
 */
 
 #endif // STB_VORBIS_HEADER_ONLY
+
+#include "soloud_file_hack_on.h"


### PR DESCRIPTION
Fixes build errors (at least on Visual Studio 2017). The last time `stb_vorbis.c` was updated, the file hack was removed from it, which creates errors while compiling `soloud_wavstream.cpp`.
