### PR TITLE
Reset number of channels properly when reloading a sample.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ amir ramezani <amir.ramezani1370@gmail.com> http://shaberoshan.ir
 Luke San Antonio Bialecki lukesanantonio@gmail.com
 Eduardo Doria Lima https://github.com/eduardodoria
 Ilya Zhuravlev https://github.com/xyzz
+Jussi Sammaltupa

--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -306,6 +306,7 @@ namespace SoLoud
 		delete[] mData;
 		mData = 0;
 		mSampleCount = 0;
+		mChannels = 1;
         int tag = aReader->read32();
 		if (tag == MAKEDWORD('O','g','g','S')) 
         {


### PR DESCRIPTION
Fixes issue #159:

SoLoud does not reset number of channels correctly when reloading a sample,
resulting in a crash if the number of channels changes from 2 to 1.

Repro:

SoLoud::Soloud soloud;
SoLoud::Wav sample;
soloud.init();
sample.load("stereo.wav");
soloud.play(sample);
printf("Press any key to load mono sample...\n");
getch();
sample.load("mono.wav");
soloud.play(sample);
printf("Press any key to exit...\n");
getch();
soloud.deinit();