### PR TITLE
Change loading of .wav files to ignore unknown chunks.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ amir ramezani <amir.ramezani1370@gmail.com> http://shaberoshan.ir
 Luke San Antonio Bialecki lukesanantonio@gmail.com
 Eduardo Doria Lima https://github.com/eduardodoria
 Ilya Zhuravlev https://github.com/xyzz
+Jussi Sammaltupa


### PR DESCRIPTION
- Reads only known chunks, ignores others
- Loops until the whole has been read
- This adds support for files with Broadcast Wave Format (BWF) chunks
- Originally by @petrihakkinen
- This fixes #161