### PR TITLE
Eliminate warnings/errors found by PVS-Studio analyzer

### DIFF
--- a/demos/virtualvoices/main.cpp
+++ b/demos/virtualvoices/main.cpp
@@ -35,7 +35,7 @@ freely, subject to the following restrictions:
 #include "soloud_speech.h"
 
 #define VOICEGRID 24
-#define VOICES VOICEGRID*VOICEGRID
+#define VOICES (VOICEGRID*VOICEGRID)
 SoLoud::Soloud gSoloud;
 SoLoud::Sfxr gSfx[VOICES];
 

--- a/src/audiosource/sfxr/soloud_sfxr.cpp
+++ b/src/audiosource/sfxr/soloud_sfxr.cpp
@@ -321,7 +321,7 @@ namespace SoLoud
 	}
 
 
-#define rnd(n) (mRand.rand()%(n+1))
+#define rnd(n) (mRand.rand()%((n)+1))
 #undef frnd
 #define frnd(x) ((float)(mRand.rand()%10001)/10000*(x))
 

--- a/src/audiosource/speech/tts.cpp
+++ b/src/audiosource/speech/tts.cpp
@@ -1376,10 +1376,9 @@ int xlate_string(const char *string, darray *phone)
 										phone->put(*s++);
 
 									s = e + 1;
-
-									break;
 								}
 							}
+							break;
 
 						default:
 							nph += spell_out(word, 1, phone);

--- a/src/audiosource/tedsid/sid.cpp
+++ b/src/audiosource/tedsid/sid.cpp
@@ -517,7 +517,8 @@ inline int SIDsound::doEnvelopeGenerator(unsigned int cycles, SIDVoice &v)
 
 				case EG_DECAY:
 					if (v.envCurrLevel != v.envSustainLevel) {
-						--v.envCurrLevel &= 0xFF;
+						--v.envCurrLevel;
+						v.envCurrLevel &= 0xFF;
 						if (!v.envCurrLevel)
 							v.egState = EG_FROZEN;
 					}

--- a/src/audiosource/tedsid/soloud_tedsid.cpp
+++ b/src/audiosource/tedsid/soloud_tedsid.cpp
@@ -163,7 +163,10 @@ namespace SoLoud
 		if (!df) return OUT_OF_MEMORY;
 		int res = df->open(aFilename);
 		if (res != SO_NO_ERROR)
+		{
+			delete df;
 			return res;
+		}
 		res = loadFile(df);
 		if (res != SO_NO_ERROR)
 		{

--- a/src/audiosource/wav/stb_vorbis.c
+++ b/src/audiosource/wav/stb_vorbis.c
@@ -1070,8 +1070,8 @@ static int compute_codewords(Codebook *c, uint8 *len, int n, uint32 *values)
       // fires, so!
       while (z > 0 && !available[z]) --z;
       if (z == 0) { return FALSE; }
-      res = available[z];
       assert(z >= 0 && z < 32);
+      res = available[z];
       available[z] = 0;
       add_entry(c, bit_reverse(res), i, m++, len[i], values);
       // propogate availability up the tree
@@ -3526,7 +3526,7 @@ static int is_whole_packet_present(stb_vorbis *f, int end_page)
       // check that we have the page header ready
       if (p + 26 >= f->stream_end)               return error(f, VORBIS_need_more_data);
       // validate the page
-      if (memcmp(p, ogg_page_header, 4))         return error(f, VORBIS_invalid_stream);
+      if (memcmp(p, ogg_page_header, 4) != 0)    return error(f, VORBIS_invalid_stream);
       if (p[4] != 0)                             return error(f, VORBIS_invalid_stream);
       if (first) { // the first segment must NOT have 'continued_packet', later ones MUST
          if (f->previous_length)
@@ -5017,8 +5017,8 @@ static int8 channel_position[7][6] =
    typedef char stb_vorbis_float_size_test[sizeof(float)==4 && sizeof(int) == 4];
    #define FASTDEF(x) float_conv x
    // add (1<<23) to convert to int, then divide by 2^SHIFT, then add 0.5/2^SHIFT to round
-   #define MAGIC(SHIFT) (1.5f * (1 << (23-SHIFT)) + 0.5f/(1 << SHIFT))
-   #define ADDEND(SHIFT) (((150-SHIFT) << 23) + (1 << 22))
+   #define MAGIC(SHIFT) (1.5f * (1 << (23-(SHIFT))) + 0.5f/(1 << (SHIFT)))
+   #define ADDEND(SHIFT) (((150-(SHIFT)) << 23) + (1 << 22))
    #define FAST_SCALED_FLOAT_TO_INT(temp,x,s) (temp.f = (x) + MAGIC(s), temp.i - ADDEND(s))
    #define check_endianness()  
 #else

--- a/src/tools/codegen/main.cpp
+++ b/src/tools/codegen/main.cpp
@@ -431,7 +431,14 @@ void parse(const char *aFilename, int aPrintProgress = 0)
 							ALLOW(",");
 							ALLOW("\n");
 							NEXTTOKEN;	
-							c->mEnum.push_back(e);
+							if (c)
+							{
+								c->mEnum.push_back(e);
+							}
+							else
+							{
+								PARSEERROR;
+							}
 						}
 					}
 					EXPECT(";");
@@ -440,7 +447,14 @@ void parse(const char *aFilename, int aPrintProgress = 0)
 				if (s == "~")
 				{
 					// non-virtual DTor
-					EXPECT(c->mName);
+					if (c)
+					{
+						EXPECT(c->mName);
+					}
+					else
+					{
+						PARSEERROR;
+					}
 					EXPECT("(");
 					EXPECT(")");
 					EXPECT(";");
@@ -491,7 +505,14 @@ void parse(const char *aFilename, int aPrintProgress = 0)
 					if (s == "~")
 					{
 						// virtual dtor
-						EXPECT(c->mName);
+						if (c)
+						{
+							EXPECT(c->mName);
+						}
+						else
+						{
+							PARSEERROR;
+						}
 						EXPECT("(");
 						EXPECT(")");
 						ALLOW("const");

--- a/src/tools/tedsid2dump/cpu.h
+++ b/src/tools/tedsid2dump/cpu.h
@@ -36,7 +36,7 @@ class CPU {
 
 	public:
 		CPU(MemoryHandler *memhandler, unsigned char *irqreg, unsigned char *cpustack);
-		~CPU();
+		virtual ~CPU();
 		void Reset(void);
 		void softreset(void);
 		void setPC(unsigned int addr);

--- a/src/tools/tedsid2dump/sid.cpp
+++ b/src/tools/tedsid2dump/sid.cpp
@@ -519,7 +519,8 @@ inline int SIDsound::doEnvelopeGenerator(unsigned int cycles, SIDVoice &v)
 
 				case EG_DECAY:
 					if (v.envCurrLevel != v.envSustainLevel) {
-						--v.envCurrLevel &= 0xFF;
+						--v.envCurrLevel;
+						v.envCurrLevel &= 0xFF;
 						if (!v.envCurrLevel)
 							v.egState = EG_FROZEN;
 					}

--- a/src/tools/tedsid2dump/tedmem.cpp
+++ b/src/tools/tedsid2dump/tedmem.cpp
@@ -124,7 +124,8 @@ TED::TED() : filter(0), sidCard(0)
 void TED::Reset()
 {
 	// clear RAM with powerup pattern
-	for (int i=0;i<RAMSIZE;Ram[i++] = (i>>1)<<1==i ? 0 : 0xFF);
+	for (int i = 0; i < RAMSIZE; i++)
+		Ram[i] = (i>>1)<<1 == i ? 0 : 0xFF;
 	// reset oscillators
 	oscillatorReset();
 	if (sidCard) sidCard->reset();
@@ -139,10 +140,8 @@ void TED::forcedReset()
 
 void TED::texttoscreen(int x,int y, const char *scrtxt)
 {
-	register int i =0;
-
-	while (scrtxt[i]!=0)
-		chrtoscreen(x+i*8,y,scrtxt[i++]);
+	for (register int i = 0; scrtxt[i] != 0; ++i)
+		chrtoscreen(x+i*8, y, scrtxt[i]);
 }
 
 void TED::chrtoscreen(int x,int y, char scrchr)

--- a/src/tools/tedsid2dump/tedsound.cpp
+++ b/src/tools/tedsid2dump/tedsound.cpp
@@ -235,7 +235,7 @@ void TED::selectWaveForm(unsigned int channel, unsigned int wave)
 void TED::setplaybackSpeed(unsigned int speed)
 {
 	unsigned int speeds[] = { 16, 8, 4, 3, 2, 1 };
-	playbackSpeed = speeds[(speed - 1) % sizeof(speeds)];
+	playbackSpeed = speeds[(speed - 1) % (sizeof(speeds)/sizeof(unsigned int))];
 }
 
 unsigned int TED::getTimeSinceLastReset()


### PR DESCRIPTION
Hello!
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A list of bugs, found using PVS-Studio analyzer:

- [V526 ](https://www.viva64.com/en/w/v526/)The 'memcmp' function returns 0 if corresponding buffers are equal. Consider examining the condition for mistakes. stb_vorbis.c 3529
- [V522 ](https://www.viva64.com/en/w/v522/)Dereferencing of the null pointer 'c' might take place. main.cpp 434
- [V567 ](https://www.viva64.com/en/w/v567/)Undefined behavior. The 'v.envCurrLevel' variable is modified while being used twice between sequence points. sid.cpp 522
- [V599 ](https://www.viva64.com/en/w/v599/)The destructor was not declared as a virtual one, although the 'CPU' class contains virtual functions. tedplay.cpp 232
- [V567 ](https://www.viva64.com/en/w/v567/)Undefined behavior. The 'i' variable is modified while being used twice between sequence points. tedmem.cpp 127
- [V567 ](https://www.viva64.com/en/w/v567/)Unspecified behavior. The order of argument evaluation is not defined for 'chrtoscreen' function. Consider inspecting the 'i' variable. tedmem.cpp 145
- [V773 ](https://www.viva64.com/en/w/v773/)The function was exited without releasing the 'df' pointer. A memory leak is possible. soloud_tedsid.cpp 166
- [V781 ](https://www.viva64.com/en/w/v781/)The value of the 'z' variable is checked after it was used. Perhaps there is a mistake in program logic. Check lines: 1073, 1074. stb_vorbis.c 1073
- [V557 ](https://www.viva64.com/en/w/v557/)Array overrun is possible. The value of '(speed - 1) % sizeof (speeds)' index could reach 23. tedsound.cpp 238
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'rnd' is a dangerous expression. The parameter 'n' must be surrounded by parentheses. soloud_sfxr.cpp 324
- [V796 ](https://www.viva64.com/en/w/v796/)It is possible that 'break' statement is missing in switch statement. tts.cpp 1382
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'MAGIC' is a dangerous expression. The parameter 'SHIFT' must be surrounded by parentheses. stb_vorbis.c 5020
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'ADDEND' is a dangerous expression. The parameter 'SHIFT' must be surrounded by parentheses. stb_vorbis.c 5021
- [V1003 ](https://www.viva64.com/en/w/v1003/)The macro 'VOICES' is a dangerous expression. The expression must be surrounded by parentheses. main.cpp 38

There are actually more warnings were found but they are not so interesting.