### PR TITLE
Speed up Wav loading.

### DIFF
--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -180,54 +180,49 @@ namespace SoLoud
 				mData = new float[samples * readchannels];
 				mSampleCount = samples;
 
-				int i, j;
 				if (bitspersample == 8)
 				{
-					for (i = 0; i < samples; i++)
+					// read the samples to a temp buffer
+					unsigned char* buffer = new unsigned char[samples * channels];
+					aReader->read(buffer, samples * channels); // TODO what to do if we could actually read less than expected?
+
+					// convert to floats and take only max two channels
+					for (int src_index = 0, dst_index = 0; dst_index < samples; dst_index++)
 					{
-						for (j = 0; j < channels; j++)
+						mData[dst_index] = ((signed)buffer[src_index++] - 128) / (float)0x80;
+
+						if (readchannels > 1)
 						{
-							if (j == 0)
-							{
-								mData[i] = ((signed)aReader->read8() - 128) / (float)0x80;
-							}
-							else
-							{
-								if (readchannels > 1 && j == 1)
-								{
-									mData[i + samples] = ((signed)aReader->read8() - 128) / (float)0x80;
-								}
-								else
-								{
-									aReader->read8();
-								}
-							}
+							mData[dst_index + samples] = ((signed)buffer[src_index++] - 128) / (float)0x80;
 						}
+
+						// skip extra channels
+						src_index += channels - readchannels;
 					}
+
+					delete[] buffer;
 				}
 				else if (bitspersample == 16)
 				{
-					for (i = 0; i < samples; i++)
+					// read the samples to a temp buffer
+					unsigned short* buffer = new unsigned short[samples * channels];
+					aReader->read((unsigned char*)buffer, samples * channels * 2); // TODO what to do if we could actually read less than expected?
+
+					// convert to floats and take only max two channels
+					for (int src_index = 0, dst_index = 0; dst_index < samples; dst_index++)
 					{
-						for (j = 0; j < channels; j++)
+						mData[dst_index] = ((signed short)buffer[src_index++]) / (float)0x8000;
+
+						if (readchannels > 1)
 						{
-							if (j == 0)
-							{
-								mData[i] = ((signed short)aReader->read16()) / (float)0x8000;
-							}
-							else
-							{
-								if (readchannels > 1 && j == 1)
-								{
-									mData[i + samples] = ((signed short)aReader->read16()) / (float)0x8000;
-								}
-								else
-								{
-									aReader->read16();
-								}
-							}
+							mData[dst_index + samples] = ((signed short)buffer[src_index++]) / (float)0x8000;
 						}
+
+						// skip extra channels
+						src_index += channels - readchannels;
 					}
+
+					delete[] buffer;
 				}
 			}
 


### PR DESCRIPTION
Glad to see you back on the project!

This is one of those changes mentioned by Petri H in Twitter.
Disclaimer: Like Petri said, our version has diverged a bit. At the moment, I can't even compile SoLoud for some reason ('set3dProcessing' : is not a member of 'SoLoud::Bus'), so I haven't actually tested the code in SoLoud proper. Ahem. However, we've been using this patch since November 2017 without any problems.

But what is going on here? We profiled our game startup a bit, and noticed that significant time (>50%) was spent loading .wav files. 

Wav::loadwav was really slow because it loaded the files one byte at a time from the filesystem. This patch modifies pm. method to allocate a temp buffer and load the wav in one go, resulting in huge speed up. Sorry, I don't have the numbers anymore. But it's a fraction of what it used to be.

There is one loose end; what if we have a corrupted file and can not read as many bytes as there should be? Being the lazy bum I am, I did not figure out how to properly implement that and for our game, it was OK to just ignore the situation, but I suppose it's not acceptable for SoLoud. Return FILE_LOAD_FAILED? Some other error code to differentiate between different causes of failure?