### PR TITLE
PLEASE DO NOT MERGE: Preallocated resampling buffers

### DIFF
--- a/include/soloud.h
+++ b/include/soloud.h
@@ -62,7 +62,7 @@ freely, subject to the following restrictions:
 #define SAMPLE_GRANULARITY 512
 
 // Maximum number of concurrent voices (hard limit is 4095)
-#define VOICE_COUNT 1024
+#define VOICE_COUNT 256
 
 // Use linear resampler
 #define RESAMPLER_LINEAR
@@ -386,6 +386,9 @@ namespace SoLoud
 		AlignedFloatBuffer mOutputScratch;
 		// Audio voices.
 		AudioSourceInstance *mVoice[VOICE_COUNT];
+		// Resampling buffers for voices.
+		float mResamplingBuffers[VOICE_COUNT * 2 * SAMPLE_GRANULARITY * MAX_CHANNELS];
+
 		// Output sample rate (not float)
 		unsigned int mSamplerate;
 		// Output channel count

--- a/include/soloud_audiosource.h
+++ b/include/soloud_audiosource.h
@@ -35,13 +35,6 @@ namespace SoLoud
 	class AudioSourceInstance;
 	class AudioSourceInstance3dData;
 
-	struct AudioSourceResampleData
-	{
-		AudioSourceResampleData();
-		~AudioSourceResampleData();
-		float *mBuffer;
-	};
-
 	class AudioCollider
 	{
 	public:
@@ -181,7 +174,7 @@ namespace SoLoud
 		// Initialize instance. Mostly internal use.
 		void init(AudioSource &aSource, int aPlayIndex);
 		// Buffers for the resampler
-		AudioSourceResampleData *mResampleData[2];
+		float *mResampleData[2];
 		// Sub-sample playhead; 16.16 fixed point
 		unsigned int mSrcOffset;
 		// Samples left over from earlier pass

--- a/src/c_api/soloud.def
+++ b/src/c_api/soloud.def
@@ -125,7 +125,6 @@ EXPORTS
 	Bus_set3dMinMaxDistance
 	Bus_set3dAttenuation
 	Bus_set3dDopplerFactor
-	Bus_set3dProcessing
 	Bus_set3dListenerRelative
 	Bus_set3dDistanceDelay
 	Bus_set3dCollider
@@ -150,7 +149,6 @@ EXPORTS
 	Speech_set3dMinMaxDistance
 	Speech_set3dAttenuation
 	Speech_set3dDopplerFactor
-	Speech_set3dProcessing
 	Speech_set3dListenerRelative
 	Speech_set3dDistanceDelay
 	Speech_set3dCollider
@@ -171,7 +169,6 @@ EXPORTS
 	Wav_set3dMinMaxDistance
 	Wav_set3dAttenuation
 	Wav_set3dDopplerFactor
-	Wav_set3dProcessing
 	Wav_set3dListenerRelative
 	Wav_set3dDistanceDelay
 	Wav_set3dCollider
@@ -194,7 +191,6 @@ EXPORTS
 	WavStream_set3dMinMaxDistance
 	WavStream_set3dAttenuation
 	WavStream_set3dDopplerFactor
-	WavStream_set3dProcessing
 	WavStream_set3dListenerRelative
 	WavStream_set3dDistanceDelay
 	WavStream_set3dCollider
@@ -220,7 +216,6 @@ EXPORTS
 	Sfxr_set3dMinMaxDistance
 	Sfxr_set3dAttenuation
 	Sfxr_set3dDopplerFactor
-	Sfxr_set3dProcessing
 	Sfxr_set3dListenerRelative
 	Sfxr_set3dDistanceDelay
 	Sfxr_set3dCollider
@@ -247,7 +242,6 @@ EXPORTS
 	Openmpt_set3dMinMaxDistance
 	Openmpt_set3dAttenuation
 	Openmpt_set3dDopplerFactor
-	Openmpt_set3dProcessing
 	Openmpt_set3dListenerRelative
 	Openmpt_set3dDistanceDelay
 	Openmpt_set3dCollider
@@ -269,7 +263,6 @@ EXPORTS
 	Monotone_set3dMinMaxDistance
 	Monotone_set3dAttenuation
 	Monotone_set3dDopplerFactor
-	Monotone_set3dProcessing
 	Monotone_set3dListenerRelative
 	Monotone_set3dDistanceDelay
 	Monotone_set3dCollider
@@ -291,7 +284,6 @@ EXPORTS
 	TedSid_set3dMinMaxDistance
 	TedSid_set3dAttenuation
 	TedSid_set3dDopplerFactor
-	TedSid_set3dProcessing
 	TedSid_set3dListenerRelative
 	TedSid_set3dDistanceDelay
 	TedSid_set3dCollider

--- a/src/c_api/soloud_c.cpp
+++ b/src/c_api/soloud_c.cpp
@@ -801,12 +801,6 @@ void Bus_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 	cl->set3dDopplerFactor(aDopplerFactor);
 }
 
-void Bus_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Bus * cl = (Bus *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
-}
-
 void Bus_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
 {
 	Bus * cl = (Bus *)aClassPtr;
@@ -943,12 +937,6 @@ void Speech_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 	cl->set3dDopplerFactor(aDopplerFactor);
 }
 
-void Speech_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Speech * cl = (Speech *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
-}
-
 void Speech_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
 {
 	Speech * cl = (Speech *)aClassPtr;
@@ -1065,12 +1053,6 @@ void Wav_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 {
 	Wav * cl = (Wav *)aClassPtr;
 	cl->set3dDopplerFactor(aDopplerFactor);
-}
-
-void Wav_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Wav * cl = (Wav *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
 }
 
 void Wav_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
@@ -1201,12 +1183,6 @@ void WavStream_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 {
 	WavStream * cl = (WavStream *)aClassPtr;
 	cl->set3dDopplerFactor(aDopplerFactor);
-}
-
-void WavStream_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	WavStream * cl = (WavStream *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
 }
 
 void WavStream_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
@@ -1353,12 +1329,6 @@ void Sfxr_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 {
 	Sfxr * cl = (Sfxr *)aClassPtr;
 	cl->set3dDopplerFactor(aDopplerFactor);
-}
-
-void Sfxr_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Sfxr * cl = (Sfxr *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
 }
 
 void Sfxr_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
@@ -1511,12 +1481,6 @@ void Openmpt_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 	cl->set3dDopplerFactor(aDopplerFactor);
 }
 
-void Openmpt_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Openmpt * cl = (Openmpt *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
-}
-
 void Openmpt_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
 {
 	Openmpt * cl = (Openmpt *)aClassPtr;
@@ -1641,12 +1605,6 @@ void Monotone_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 	cl->set3dDopplerFactor(aDopplerFactor);
 }
 
-void Monotone_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	Monotone * cl = (Monotone *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
-}
-
 void Monotone_set3dListenerRelative(void * aClassPtr, int aListenerRelative)
 {
 	Monotone * cl = (Monotone *)aClassPtr;
@@ -1769,12 +1727,6 @@ void TedSid_set3dDopplerFactor(void * aClassPtr, float aDopplerFactor)
 {
 	TedSid * cl = (TedSid *)aClassPtr;
 	cl->set3dDopplerFactor(aDopplerFactor);
-}
-
-void TedSid_set3dProcessing(void * aClassPtr, int aDo3dProcessing)
-{
-	TedSid * cl = (TedSid *)aClassPtr;
-	cl->set3dProcessing(!!aDo3dProcessing);
 }
 
 void TedSid_set3dListenerRelative(void * aClassPtr, int aListenerRelative)

--- a/src/core/soloud.cpp
+++ b/src/core/soloud.cpp
@@ -857,7 +857,7 @@ namespace SoLoud
 					if (voice->mLeftoverSamples == 0)
 					{
 						// Swap resample buffers (ping-pong)
-						AudioSourceResampleData * t = voice->mResampleData[0];
+						float* t = voice->mResampleData[0];
 						voice->mResampleData[0] = voice->mResampleData[1];
 						voice->mResampleData[1] = t;
 
@@ -865,11 +865,11 @@ namespace SoLoud
 
 						if (voice->hasEnded())
 						{
-							memset(voice->mResampleData[0]->mBuffer, 0, sizeof(float) * SAMPLE_GRANULARITY * voice->mChannels);
+							memset(voice->mResampleData[0], 0, sizeof(float) * SAMPLE_GRANULARITY * voice->mChannels);
 						}
 						else
 						{
-							voice->getAudio(voice->mResampleData[0]->mBuffer, SAMPLE_GRANULARITY);
+							voice->getAudio(voice->mResampleData[0], SAMPLE_GRANULARITY);
 						}
 
 						
@@ -894,7 +894,7 @@ namespace SoLoud
 							if (voice->mFilter[j])
 							{
 								voice->mFilter[j]->filter(
-									voice->mResampleData[0]->mBuffer,
+									voice->mResampleData[0],
 									SAMPLE_GRANULARITY, 
 									voice->mChannels,
 									voice->mSamplerate,
@@ -934,8 +934,8 @@ namespace SoLoud
 					{
 						for (j = 0; j < voice->mChannels; j++)
 						{
-							resample(voice->mResampleData[0]->mBuffer + SAMPLE_GRANULARITY * j,
-								voice->mResampleData[1]->mBuffer + SAMPLE_GRANULARITY * j,
+							resample(voice->mResampleData[0] + SAMPLE_GRANULARITY * j,
+								voice->mResampleData[1] + SAMPLE_GRANULARITY * j,
 									 aScratch + aSamples * j + outofs, 
 									 voice->mSrcOffset,
 									 writesamples,
@@ -1229,7 +1229,7 @@ namespace SoLoud
 					if (voice->mLeftoverSamples == 0)
 					{
 						// Swap resample buffers (ping-pong)
-						AudioSourceResampleData * t = voice->mResampleData[0];
+						float* t = voice->mResampleData[0];
 						voice->mResampleData[0] = voice->mResampleData[1];
 						voice->mResampleData[1] = t;
 
@@ -1237,7 +1237,7 @@ namespace SoLoud
 
 						if (!voice->hasEnded())
 						{
-							voice->getAudio(voice->mResampleData[0]->mBuffer, SAMPLE_GRANULARITY);
+							voice->getAudio(voice->mResampleData[0], SAMPLE_GRANULARITY);
 						}
 
 

--- a/src/core/soloud_audiosource.cpp
+++ b/src/core/soloud_audiosource.cpp
@@ -59,16 +59,6 @@ namespace SoLoud
 		mDopplerValue = 1.0f;
 	}
 
-	AudioSourceResampleData::AudioSourceResampleData()
-	{
-		mBuffer = 0;
-	}
-	
-	AudioSourceResampleData::~AudioSourceResampleData()
-	{
-		delete[] mBuffer;
-	}
-
 	AudioSourceInstance::AudioSourceInstance()
 	{
 		mPlayIndex = 0;
@@ -97,8 +87,8 @@ namespace SoLoud
 			mCurrentChannelVolume[i] = 0;
 		}
 		// behind pointers because we swap between the two buffers
-		mResampleData[0] = new AudioSourceResampleData;
-		mResampleData[1] = new AudioSourceResampleData;
+		mResampleData[0] = 0;
+		mResampleData[1] = 0;
 		mSrcOffset = 0;
 		mLeftoverSamples = 0;
 		mDelaySamples = 0;
@@ -112,8 +102,6 @@ namespace SoLoud
 		{
 			delete mFilter[i];
 		}
-		delete mResampleData[0];
-		delete mResampleData[1];
 	}
 
 	void AudioSourceInstance::init(AudioSource &aSource, int aPlayIndex)

--- a/src/core/soloud_core_basicops.cpp
+++ b/src/core/soloud_core_basicops.cpp
@@ -103,12 +103,15 @@ namespace SoLoud
 
 		int scratchneeded = SAMPLE_GRANULARITY * mVoice[ch]->mChannels;
 
-		mVoice[ch]->mResampleData[0]->mBuffer = new float[scratchneeded];
-		mVoice[ch]->mResampleData[1]->mBuffer = new float[scratchneeded];
+		float* buffer1 = (float *)((size_t)mResamplingBuffers + (ch * 2 + 0) * SAMPLE_GRANULARITY * sizeof(float) * MAX_CHANNELS);
+		float* buffer2 = (float *)((size_t)mResamplingBuffers + (ch * 2 + 1) * SAMPLE_GRANULARITY * sizeof(float) * MAX_CHANNELS);
 
-		// First buffer will be overwritten anyway; the second may be referenced by resampler
-		memset(mVoice[ch]->mResampleData[0]->mBuffer, 0, sizeof(float) * scratchneeded);
-		memset(mVoice[ch]->mResampleData[1]->mBuffer, 0, sizeof(float) * scratchneeded);
+		mVoice[ch]->mResampleData[0] = buffer1;
+		mVoice[ch]->mResampleData[1] = buffer2;
+
+		// Zero out only the part the resampler is going to need
+		memset(buffer1, 0, sizeof(float) * scratchneeded);
+		memset(buffer2, 0, sizeof(float) * scratchneeded);
 
 		unlockAudioMutex();
 


### PR DESCRIPTION
**PLEASE DO NOT MERGE**

This is just to pinpoint a problem and show our solution to the problem. I'm expecting you to decline this pull request :)

We did this change in our game to reduce the number of runtime memory allocations Soloud makes. Currently, Soloud allocates new resampling buffers for each AudioSourceInstance, which in the long run may fragment heap quite badly.

So we pre-allocated resampling buffers for all voices. To reduce the amount of memory needed, we reduced the maximum active voices to 256, which is plenty for us.

Maybe the resampling buffers should come from a pool or something?