### PR TITLE
Moving CloseHandle

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -21,3 +21,4 @@ Eduardo Doria Lima https://github.com/eduardodoria
 Ilya Zhuravlev https://github.com/xyzz
 Jussi Sammaltupa
 Tam Toucn https://github.com/TamToucan
+lamelizard

--- a/src/backend/winmm/soloud_winmm.cpp
+++ b/src/backend/winmm/soloud_winmm.cpp
@@ -97,8 +97,6 @@ namespace SoLoud
         SetEvent(data->bufferEndEvent);
         Thread::wait(data->threadHandle);
         Thread::release(data->threadHandle);
-        CloseHandle(data->audioProcessingDoneEvent);
-        CloseHandle(data->bufferEndEvent);
         waveOutReset(data->waveOut);
         for (int i=0;i<BUFFER_COUNT;++i) 
         {
@@ -109,6 +107,8 @@ namespace SoLoud
             }
         }
         waveOutClose(data->waveOut);
+        CloseHandle(data->audioProcessingDoneEvent);
+        CloseHandle(data->bufferEndEvent);
         delete data;
         aSoloud->mBackendData = 0;
     }

--- a/src/backend/xaudio2/soloud_xaudio2.cpp
+++ b/src/backend/xaudio2/soloud_xaudio2.cpp
@@ -143,8 +143,6 @@ namespace SoLoud
         SetEvent(data->bufferEndEvent);
         Thread::wait(data->thread);
         Thread::release(data->thread);
-        CloseHandle(data->bufferEndEvent);
-        CloseHandle(data->audioProcessingDoneEvent);
         if (0 != data->sourceVoice) 
         {
             data->sourceVoice->Stop();
@@ -177,6 +175,8 @@ namespace SoLoud
                 delete[] data->buffer[i];
             }
         }
+        CloseHandle(data->bufferEndEvent);
+        CloseHandle(data->audioProcessingDoneEvent);
         delete data;
         aSoloud->mBackendData = 0;
         CoUninitialize();


### PR DESCRIPTION
This fixes #186.
It was only tested on Windows 10 x64 as x86 executable.