### PR TITLE
[*] Windows compilation warning hotfix for vc++..

### DIFF
--- a/include/soloud_vizsn.h
+++ b/include/soloud_vizsn.h
@@ -2,7 +2,7 @@
 SoLoud audio engine
 Copyright (c) 2013-2018 Jari Komppa
 
-vizsn speech synthesizer (c) by Ville-Matias Heikkil‰,
+vizsn speech synthesizer (c) by Ville-Matias Heikkil√§,
 released under WTFPL, http://www.wtfpl.net/txt/copying/
 (in short, "do whatever you want to")
 

--- a/src/audiosource/tedsid/ted.cpp
+++ b/src/audiosource/tedsid/ted.cpp
@@ -140,7 +140,7 @@ inline unsigned int TED::waveTriangle(unsigned int channel)
 
 #if 0
 	msb = OSCRELOADVAL + 1 - OscReload[channel];
-	int diff = FlipFlop[channel] ? int(oscCount[channel]) - int(OscReload[channel]) 
+	int diff = FlipFlop[channel] ? int(oscCount[channel]) - int(OscReload[channel])
 		: int(OSCRELOADVAL) - int(oscCount[channel]);
 	//if (diff < 0) diff = 0;
 	//if (oscCount[channel] >= 0x3fa) diff = 0;
@@ -175,7 +175,7 @@ inline unsigned int TED::getWaveSample(unsigned int channel, unsigned int wave)
 			return waveTriangle(channel);
 			break;
 
-		// combined waveforms แ la SID
+		// combined waveforms รก la SID
 		case 3: // square + sawtooth
 			sm = waveSawTooth(channel) + waveSquare(channel);
 			return sm /= 2;


### PR DESCRIPTION
Before that pr there were 2 warnings during compilation on Windows:
[ 57%] Building CXX object CMakeFiles/soloud.dir/C_/ev/ev_evi/3rdParty/x64/unpacks/soloud/src/audiosource/vic/soloud_vic.cpp.obj
ted.cpp
C:\ev\ev_evi\3rdParty\x64\unpacks\soloud\src\audiosource\tedsid\ted.cpp: warning C4828: The file contains a character starting at offset 0x10d9 that is illegal in the current source character set (codepage 65001).
soloud_vic.cpp
[ 59%] Building CXX object CMakeFiles/soloud.dir/C_/ev/ev_evi/3rdParty/x64/unpacks/soloud/src/audiosource/vizsn/soloud_vizsn.cpp.obj
soloud_vizsn.cpp
[ 61%] Building CXX object CMakeFiles/soloud.dir/C_/ev/ev_evi/3rdParty/x64/unpacks/soloud/src/audiosource/wav/dr_impl.cpp.obj
C:\ev\ev_evi\3rdParty\x64\unpacks\soloud\contrib\..\include\soloud_vizsn.h: warning C4828: The file contains a character starting at offset 0x74 that is illegal in the current source character set (codepage 65001).

I had undefined behavior: sometimes there was a crash during SoLoud::Soloud object creation. After this hotfix problem is gone. I have just changed encoding of corresponding files to UTF8.