### PR TITLE
Better namespacing for openDll et al. functions for varied backends.

### DIFF
--- a/src/backend/openal/soloud_openal_dll.c
+++ b/src/backend/openal/soloud_openal_dll.c
@@ -21,6 +21,8 @@ freely, subject to the following restrictions:
    3. This notice may not be removed or altered from any source
    distribution.
 */
+#if defined(WITH_OPENAL)
+
 #include <stdlib.h>
 #include <math.h>
 
@@ -39,7 +41,10 @@ freely, subject to the following restrictions:
 
 #ifdef SOLOUD_STATIC_OPENAL
 
-// statically linked OpenAL 
+extern "C"
+{
+
+// statically linked OpenAL
 int dll_al_found() { return 1; }
 ALCdevice* dll_alc_OpenDevice(const ALCchar *devicename) { return alcOpenDevice(devicename); }
 void dll_alc_CloseDevice(ALCdevice *device) { alcCloseDevice(device); }
@@ -56,6 +61,8 @@ void dll_al_GenBuffers(ALsizei n, ALuint *buffers) { alGenBuffers(n, buffers); }
 void dll_al_DeleteBuffers(ALsizei n, ALuint *buffers) { alDeleteBuffers(n, buffers); }
 void dll_al_GenSources(ALsizei n, ALuint *sources) { alGenSources(n, sources); }
 void dll_al_DeleteSources(ALsizei n, ALuint *sources) { alDeleteSources(n, sources); }
+
+}
 
 #else
 
@@ -94,14 +101,14 @@ static al_DeleteSources dAlDeleteSources;
 #ifdef WINDOWS_VERSION
 #include <windows.h>
 
-static HMODULE openDll()
+static HMODULE oal_openDll()
 {
 	HMODULE x = LoadLibraryA("soft_oal.dll");
 	if (x == 0) x = LoadLibraryA("OpenAL32.dll");
 	return x;
 }
 
-static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
+static void* oal_getDllProc(HMODULE aDllHandle, const char *aProcName)
 {
     return GetProcAddress(aDllHandle, aProcName);
 }
@@ -111,19 +118,22 @@ static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
 
 typedef void* HMODULE;
 
-static HMODULE openDll()
+static HMODULE oal_openDll()
 {
     return dlopen("libopenal.so", RTLD_LAZY);
 }
 
-static void* getDllProc(HMODULE aLibrary, const char *aProcName)
+static void* oal_getDllProc(HMODULE aLibrary, const char *aProcName)
 {
     return dlsym(aLibrary, aProcName);
 }
 
 #endif
 
-static int load_dll()
+extern "C"
+{
+
+static int oal_load_dll()
 {
 #ifdef WINDOWS_VERSION
 	HMODULE dll = NULL;
@@ -136,25 +146,25 @@ static int load_dll()
 		return 1;
 	}
 
-    dll = openDll();
+    dll = oal_openDll();
 
     if (dll)
     {
-        dAlcOpenDevice = (alc_OpenDevice)getDllProc(dll, "alcOpenDevice");
-        dAlcCloseDevice = (alc_CloseDevice)getDllProc(dll, "alcCloseDevice");
-        dAlcCreateContext = (alc_CreateContext)getDllProc(dll, "alcCreateContext");
-        dAlcDestroyContext = (alc_DestroyContext)getDllProc(dll, "alcDestroyContext");
-        dAlcMakeContextCurrent = (alc_MakeContextCurrent)getDllProc(dll, "alcMakeContextCurrent");
-        dAlGetSourcei = (al_GetSourcei)getDllProc(dll, "alGetSourcei");
-        dAlSourceQueueBuffers = (al_SourceQueueBuffers)getDllProc(dll, "alSourceQueueBuffers");
-        dAlSourceUnqueueBuffers = (al_SourceUnqueueBuffers)getDllProc(dll, "alSourceUnqueueBuffers");
-        dAlBufferData = (al_BufferData)getDllProc(dll, "alBufferData");
-        dAlSourcePlay = (al_SourcePlay)getDllProc(dll, "alSourcePlay");
-        dAlSourceStop = (al_SourceStop)getDllProc(dll, "alSourceStop");
-        dAlGenBuffers = (al_GenBuffers)getDllProc(dll, "alGenBuffers");
-        dAlDeleteBuffers = (al_GenBuffers)getDllProc(dll, "alDeleteBuffers");
-        dAlGenSources = (al_GenSources)getDllProc(dll, "alGenSources");
-        dAlDeleteSources = (al_GenSources)getDllProc(dll, "alDeleteSources");
+        dAlcOpenDevice = (alc_OpenDevice)oal_getDllProc(dll, "alcOpenDevice");
+        dAlcCloseDevice = (alc_CloseDevice)oal_getDllProc(dll, "alcCloseDevice");
+        dAlcCreateContext = (alc_CreateContext)oal_getDllProc(dll, "alcCreateContext");
+        dAlcDestroyContext = (alc_DestroyContext)oal_getDllProc(dll, "alcDestroyContext");
+        dAlcMakeContextCurrent = (alc_MakeContextCurrent)oal_getDllProc(dll, "alcMakeContextCurrent");
+        dAlGetSourcei = (al_GetSourcei)oal_getDllProc(dll, "alGetSourcei");
+        dAlSourceQueueBuffers = (al_SourceQueueBuffers)oal_getDllProc(dll, "alSourceQueueBuffers");
+        dAlSourceUnqueueBuffers = (al_SourceUnqueueBuffers)oal_getDllProc(dll, "alSourceUnqueueBuffers");
+        dAlBufferData = (al_BufferData)oal_getDllProc(dll, "alBufferData");
+        dAlSourcePlay = (al_SourcePlay)oal_getDllProc(dll, "alSourcePlay");
+        dAlSourceStop = (al_SourceStop)oal_getDllProc(dll, "alSourceStop");
+        dAlGenBuffers = (al_GenBuffers)oal_getDllProc(dll, "alGenBuffers");
+        dAlDeleteBuffers = (al_GenBuffers)oal_getDllProc(dll, "alDeleteBuffers");
+        dAlGenSources = (al_GenSources)oal_getDllProc(dll, "alGenSources");
+        dAlDeleteSources = (al_GenSources)oal_getDllProc(dll, "alDeleteSources");
 
         if (dAlcOpenDevice &&
         	dAlcCloseDevice &&
@@ -164,7 +174,7 @@ static int load_dll()
             dAlGetSourcei &&
 			dAlSourceQueueBuffers &&
             dAlSourceUnqueueBuffers &&
-			dAlBufferData && 
+			dAlBufferData &&
 			dAlSourcePlay &&
 			dAlSourceStop &&
             dAlGenBuffers &&
@@ -181,100 +191,103 @@ static int load_dll()
 
 int dll_al_found()
 {
-	return load_dll();
+	return oal_load_dll();
 }
 
 ALCdevice* dll_alc_OpenDevice(const ALCchar *devicename)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		return dAlcOpenDevice(devicename);
 	return NULL;
 }
 
 void dll_alc_CloseDevice(ALCdevice *device)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlcCloseDevice(device);
 }
 
 ALCcontext* dll_alc_CreateContext(ALCdevice *device, const ALCint* attrlist)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		return dAlcCreateContext(device, attrlist);
 	return NULL;
 }
 
 void dll_alc_DestroyContext(ALCcontext *context)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlcDestroyContext(context);
 }
 
 ALCboolean dll_alc_MakeContextCurrent(ALCcontext *context)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		return dAlcMakeContextCurrent(context);
 	return 0;
 }
 
 void dll_al_GetSourcei(ALuint source, ALenum param, ALint *value)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlGetSourcei(source, param, value);
 }
 
 void dll_al_SourceQueueBuffers(ALuint source, ALsizei nb, const ALuint *buffers)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlSourceQueueBuffers(source, nb, buffers);
 }
 
 void dll_al_SourceUnqueueBuffers(ALuint source, ALsizei nb, ALuint *buffers)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlSourceUnqueueBuffers(source, nb, buffers);
 }
 
 void dll_al_BufferData(ALuint buffer, ALenum format, const ALvoid *data, ALsizei size, ALsizei freq)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlBufferData(buffer, format, data, size, freq);
 }
 
 void dll_al_SourcePlay(ALuint source)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlSourcePlay(source);
 }
 
 void dll_al_SourceStop(ALuint source)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlSourceStop(source);
 }
 
 void dll_al_GenBuffers(ALsizei n, ALuint *buffers)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlGenBuffers(n, buffers);
 }
 
 void dll_al_DeleteBuffers(ALsizei n, ALuint *buffers)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlDeleteBuffers(n, buffers);
 }
 
 void dll_al_GenSources(ALsizei n, ALuint *sources)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlGenSources(n, sources);
 }
 
 void dll_al_DeleteSources(ALsizei n, ALuint *sources)
 {
-	if (load_dll())
+	if (oal_load_dll())
 		dAlDeleteSources(n, sources);
 }
 
+}
+
+#endif
 #endif

--- a/src/backend/portaudio/soloud_portaudio_dll.c
+++ b/src/backend/portaudio/soloud_portaudio_dll.c
@@ -21,6 +21,8 @@ freely, subject to the following restrictions:
    3. This notice may not be removed or altered from any source
    distribution.
 */
+#if defined(WITH_PORTAUDIO)
+
 #include <stdlib.h>
 #include <math.h>
 
@@ -54,13 +56,13 @@ static Pa_OpenDefaultStreamProc dPa_OpenDefaultStream = NULL;
 #ifdef WINDOWS_VERSION
 #include <windows.h>
 
-static HMODULE openDll()
+static HMODULE pta_openDll()
 {
     HMODULE dllh = LoadLibrary("portaudio_x86.dll");
     return dllh;
 }
 
-static void *getdllproc(HMODULE dllhandle, const char *procname)
+static void *pta_getdllproc(HMODULE dllhandle, const char *procname)
 {
     HMODULE dllh = (HMODULE)dllhandle;
     return GetProcAddress(dllh, procname);
@@ -69,7 +71,7 @@ static void *getdllproc(HMODULE dllhandle, const char *procname)
 #else
 #include <dlfcn.h> // dll functions
 
-static void* openDll()
+static void* pta_openDll()
 {
     void* res = dlopen("libportaudio_x86.so", RTLD_LAZY);
 
@@ -78,7 +80,7 @@ static void* openDll()
 	return res;
 }
 
-static void *getdllproc(void* dllhandle, const char *procname)
+static void *pta_getdllproc(void* dllhandle, const char *procname)
 {
     void* library = dllhandle;
     return dlsym(library,procname);
@@ -88,7 +90,7 @@ static void *getdllproc(void* dllhandle, const char *procname)
 
 
 
-static int load_dll()
+static int pta_load_dll()
 {
 #ifdef WINDOWS_VERSION
 	HMODULE dll = NULL;
@@ -101,15 +103,15 @@ static int load_dll()
 		return 1;
 	}
 
-    dll = openDll();
+    dll = pta_openDll();
 
     if (dll)
     {
-		dPa_Initialize = (Pa_InitializeProc)getdllproc(dll,"Pa_Initialize");
-		dPa_Terminate = (Pa_TerminateProc)getdllproc(dll,"Pa_Terminate");
-		dPa_CloseStream = (Pa_CloseStreamProc)getdllproc(dll,"Pa_CloseStream");
-		dPa_StartStream = (Pa_StartStreamProc)getdllproc(dll,"Pa_StartStream");
-		dPa_OpenDefaultStream = (Pa_OpenDefaultStreamProc)getdllproc(dll,"Pa_OpenDefaultStream");
+		dPa_Initialize = (Pa_InitializeProc)pta_getdllproc(dll,"Pa_Initialize");
+		dPa_Terminate = (Pa_TerminateProc)pta_getdllproc(dll,"Pa_Terminate");
+		dPa_CloseStream = (Pa_CloseStreamProc)pta_getdllproc(dll,"Pa_CloseStream");
+		dPa_StartStream = (Pa_StartStreamProc)pta_getdllproc(dll,"Pa_StartStream");
+		dPa_OpenDefaultStream = (Pa_OpenDefaultStreamProc)pta_getdllproc(dll,"Pa_OpenDefaultStream");
 
 		if (dPa_Initialize == NULL ||
 			dPa_Terminate == NULL ||
@@ -122,38 +124,38 @@ static int load_dll()
 		}
 		return 1;
 	}
-	return 0;	
+	return 0;
 }
 
 int dll_Pa_found()
 {
-	return load_dll();
+	return pta_load_dll();
 }
 
 PaError dll_Pa_Initialize( void )
 {
-	if (load_dll())
+	if (pta_load_dll())
 		return dPa_Initialize();
 	return paNotInitialized;
 }
 
 PaError dll_Pa_Terminate( void )
 {
-	if (load_dll())
+	if (pta_load_dll())
 		return dPa_Terminate();
 	return paNotInitialized;
 }
 
 PaError dll_Pa_CloseStream( PaStream *stream )
 {
-	if (load_dll())
+	if (pta_load_dll())
 		return dPa_CloseStream(stream);
 	return paNotInitialized;
 }
 
 PaError dll_Pa_StartStream( PaStream *stream )
 {
-	if (load_dll())
+	if (pta_load_dll())
 		return dPa_StartStream(stream);
 	return paNotInitialized;
 }
@@ -167,8 +169,9 @@ PaError dll_Pa_OpenDefaultStream( PaStream** stream,
                             PaStreamCallback *streamCallback,
                             void *userData )
 {
-	if (load_dll())
+	if (pta_load_dll())
 		return dPa_OpenDefaultStream(stream,numInputChannels,numOutputChannels,sampleFormat,sampleRate,framesPerBuffer,streamCallback,userData);
 	return paNotInitialized;
 }
 
+#endif

--- a/src/backend/sdl/soloud_sdl1_dll.c
+++ b/src/backend/sdl/soloud_sdl1_dll.c
@@ -21,6 +21,8 @@ freely, subject to the following restrictions:
    3. This notice may not be removed or altered from any source
    distribution.
 */
+#if defined(WITH_SDL)
+
 #include <stdlib.h>
 #if defined(_MSC_VER)
 #define WINDOWS_VERSION
@@ -41,13 +43,13 @@ static SDLPauseAudio dSDL1_PauseAudio = NULL;
 #ifdef WINDOWS_VERSION
 #include <windows.h>
 
-static HMODULE openDll()
+static HMODULE sdl1_openDll()
 {
 	HMODULE res = LoadLibraryA("SDL.dll");
     return res;
 }
 
-static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
+static void* sdl1_getDllProc(HMODULE aDllHandle, const char *aProcName)
 {
     return GetProcAddress(aDllHandle, aProcName);
 }
@@ -55,7 +57,7 @@ static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
 #else
 #include <dlfcn.h> // dll functions
 
-static void * openDll()
+static void * sdl1_openDll()
 {
 	void * res;
 	res = dlopen("/Library/Frameworks/SDL.framework/SDL", RTLD_LAZY);
@@ -64,14 +66,14 @@ static void * openDll()
     return res;
 }
 
-static void* getDllProc(void * aLibrary, const char *aProcName)
+static void* sdl1_getDllProc(void * aLibrary, const char *aProcName)
 {
     return dlsym(aLibrary, aProcName);
 }
 
 #endif
 
-static int load_dll()
+static int sdl1_load_dll()
 {
 #ifdef WINDOWS_VERSION
 	HMODULE dll = NULL;
@@ -84,16 +86,16 @@ static int load_dll()
 		return 1;
 	}
 
-    dll = openDll();
+    dll = sdl1_openDll();
 
     if (dll)
     {
-	    dSDL1_OpenAudio = (SDLOpenAudio)getDllProc(dll, "SDL_OpenAudio");
-	    dSDL1_CloseAudio = (SDLCloseAudio)getDllProc(dll, "SDL_CloseAudio");
-	    dSDL1_PauseAudio = (SDLPauseAudio)getDllProc(dll, "SDL_PauseAudio");
+	    dSDL1_OpenAudio = (SDLOpenAudio)sdl1_getDllProc(dll, "SDL_OpenAudio");
+	    dSDL1_CloseAudio = (SDLCloseAudio)sdl1_getDllProc(dll, "SDL_CloseAudio");
+	    dSDL1_PauseAudio = (SDLPauseAudio)sdl1_getDllProc(dll, "SDL_PauseAudio");
 
 
-        if (dSDL1_OpenAudio && 
+        if (dSDL1_OpenAudio &&
         	dSDL1_CloseAudio &&
         	dSDL1_PauseAudio)
         {
@@ -106,24 +108,26 @@ static int load_dll()
 
 int dll_SDL1_found()
 {
-	return load_dll();
+	return sdl1_load_dll();
 }
 
 int dll_SDL1_OpenAudio(SDL_AudioSpec *desired, SDL_AudioSpec *obtained)
 {
-	if (load_dll())
+	if (sdl1_load_dll())
 		return dSDL1_OpenAudio(desired, obtained);
 	return 0;
 }
 
 void dll_SDL1_CloseAudio()
 {
-	if (load_dll())
+	if (sdl1_load_dll())
 		dSDL1_CloseAudio();
 }
 
 void dll_SDL1_PauseAudio(int pause_on)
 {
-	if (load_dll())
+	if (sdl1_load_dll())
 		dSDL1_PauseAudio(pause_on);
 }
+
+#endif

--- a/src/backend/sdl/soloud_sdl2_dll.c
+++ b/src/backend/sdl/soloud_sdl2_dll.c
@@ -21,6 +21,8 @@ freely, subject to the following restrictions:
    3. This notice may not be removed or altered from any source
    distribution.
 */
+#if defined(WITH_SDL2)
+
 #include <stdlib.h>
 #if defined(_MSC_VER)
 #define WINDOWS_VERSION
@@ -47,17 +49,17 @@ static SDL2_InitSubSystem_t SDL2_InitSubSystem = NULL;
 static SDL2_OpenAudioDevice_t SDL2_OpenAudioDevice = NULL;
 static SDL2_CloseAudioDevice_t SDL2_CloseAudioDevice = NULL;
 static SDL2_PauseAudioDevice_t SDL2_PauseAudioDevice = NULL;
-	
+
 #ifdef WINDOWS_VERSION
 #include <windows.h>
 
-static HMODULE openDll()
+static HMODULE sdl2_openDll()
 {
 	HMODULE res = LoadLibraryA("SDL2.dll");
     return res;
 }
 
-static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
+static void* sdl2_getDllProc(HMODULE aDllHandle, const char *aProcName)
 {
     return GetProcAddress(aDllHandle, aProcName);
 }
@@ -65,7 +67,7 @@ static void* getDllProc(HMODULE aDllHandle, const char *aProcName)
 #else
 #include <dlfcn.h> // dll functions
 
-static void * openDll()
+static void * sdl2_openDll()
 {
 	void * res;
 	res = dlopen("/Library/Frameworks/SDL2.framework/SDL2", RTLD_LAZY);
@@ -74,14 +76,14 @@ static void * openDll()
     return res;
 }
 
-static void* getDllProc(void * aLibrary, const char *aProcName)
+static void* sdl2_getDllProc(void * aLibrary, const char *aProcName)
 {
     return dlsym(aLibrary, aProcName);
 }
 
 #endif
 
-static int load_dll()
+static int sdl2_load_dll()
 {
 #ifdef WINDOWS_VERSION
 	HMODULE dll = NULL;
@@ -94,17 +96,17 @@ static int load_dll()
 		return 1;
 	}
 
-    dll = openDll();
+    dll = sdl2_openDll();
 
     if (dll)
     {
-		SDL2_WasInit = (SDL2_WasInit_t)getDllProc(dll, "SDL_WasInit");
-		SDL2_InitSubSystem = (SDL2_InitSubSystem_t)getDllProc(dll, "SDL_InitSubSystem");
-		SDL2_OpenAudioDevice = (SDL2_OpenAudioDevice_t)getDllProc(dll, "SDL_OpenAudioDevice");
-		SDL2_CloseAudioDevice = (SDL2_CloseAudioDevice_t)getDllProc(dll, "SDL_CloseAudioDevice");
-		SDL2_PauseAudioDevice = (SDL2_PauseAudioDevice_t)getDllProc(dll, "SDL_PauseAudioDevice");
-	
-        if (SDL2_WasInit && 
+		SDL2_WasInit = (SDL2_WasInit_t)sdl2_getDllProc(dll, "SDL_WasInit");
+		SDL2_InitSubSystem = (SDL2_InitSubSystem_t)sdl2_getDllProc(dll, "SDL_InitSubSystem");
+		SDL2_OpenAudioDevice = (SDL2_OpenAudioDevice_t)sdl2_getDllProc(dll, "SDL_OpenAudioDevice");
+		SDL2_CloseAudioDevice = (SDL2_CloseAudioDevice_t)sdl2_getDllProc(dll, "SDL_CloseAudioDevice");
+		SDL2_PauseAudioDevice = (SDL2_PauseAudioDevice_t)sdl2_getDllProc(dll, "SDL_PauseAudioDevice");
+
+        if (SDL2_WasInit &&
         	SDL2_InitSubSystem &&
         	SDL2_OpenAudioDevice &&
 			SDL2_CloseAudioDevice &&
@@ -119,7 +121,7 @@ static int load_dll()
 
 int dll_SDL2_found()
 {
-	return load_dll();
+	return sdl2_load_dll();
 }
 
 Uint32 dll_SDL2_WasInit(Uint32 flags)
@@ -159,3 +161,5 @@ void dll_SDL2_PauseAudioDevice(SDL_AudioDeviceID dev,
 	if (SDL2_PauseAudioDevice)
 		SDL2_PauseAudioDevice(dev, pause_on);
 }
+
+#endif


### PR DESCRIPTION
Check for WITH_X in the dll implementation for these backends.
This facilitates building amalgamated source code and does not impact
upstream maintenance.
Tested on Linux and Windows with most backends enabled at once.