### PR TITLE
Fix for #201 : WavStream::getLength reports doubled length for stereo tracks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Tapio Vierros https://github.com/tapio
 Danny Angelo Carminati Grein https://github.com/fungos
 Igor Ivanov https://github.com/laptabrok
 Matthew O'Connell https://github.com/matthew-oconnell
+Giancarlo França https://github.com/gVirtu

--- a/src/audiosource/wav/soloud_wav.cpp
+++ b/src/audiosource/wav/soloud_wav.cpp
@@ -100,7 +100,7 @@ namespace SoLoud
 			return FILE_LOAD_FAILED;
 		}
 
-		drwav_uint64 samples = decoder.totalSampleCount / decoder.channels;
+		drwav_uint64 samples = decoder.totalPCMFrameCount;
 
 		if (!samples)
 		{

--- a/src/audiosource/wav/soloud_wavstream.cpp
+++ b/src/audiosource/wav/soloud_wavstream.cpp
@@ -412,7 +412,7 @@ namespace SoLoud
 		}
 
 		mBaseSamplerate = (float)decoder->sampleRate;
-		mSampleCount = (unsigned int)decoder->totalSampleCount;
+		mSampleCount = (unsigned int)decoder->totalPCMFrameCount;
 		mFiletype = WAVSTREAM_WAV;
 		drwav_close(decoder);
 


### PR DESCRIPTION
This PR closes #201 .

I've recently stumbled upon SoLoud and I'm still amazed at how simple and straightforward it is compared to everything else out there! As a token of gratitude, I figured I could attempt to contribute somehow.

Intuitively, I figured this change would go into `WavStream::getLength` itself to minimize the chances of breaking something else. However, after some testing, I noticed that this problem was occurring only with **stereo WAV files** (both PCM and compressed), and **not** with stereo OGGs, MP3s or FLACs. I envisioned the following alternatives:

 * Code the fix into dr_wav itself
 * Adjust the resulting sample count upon importing the wav file
 * Check the file type in `getLength` and adjust accordingly

~~The second approach seemed fair as it was not only dead simple to implement, but also has negligible performance implications. This assumes mChannels will never ever be zero. Should we check for that condition or is it covered by the `decoder == NULL` case?~~

EDIT: Thanks to @mackron the fix is already present in dr_wav 0.9.0. Thus, this fix is simply a matter of updating the included version and adapting where due. Going over the deprecated APIs, it seems only `drwav::totalSampleCount` was in use.

Let me know what you think and I'll amend accordingly. :)