### PR TITLE
No-sound null driver

### DIFF
--- a/src/backend/null/soloud_null.cpp
+++ b/src/backend/null/soloud_null.cpp
@@ -1,6 +1,6 @@
 /*
 SoLoud audio engine
-Copyright (c) 2013-2015 Jari Komppa
+Copyright (c) 2013-2019 Jari Komppa
 
 This software is provided 'as-is', without any express or implied
 warranty. In no event will the authors be held liable for any damages
@@ -23,6 +23,7 @@ freely, subject to the following restrictions:
 */
 
 #include "soloud.h"
+#include "soloud_thread.h"
 
 #if !defined(WITH_NULL)
 
@@ -38,18 +39,82 @@ namespace SoLoud
 
 namespace SoLoud
 {
+    struct SoLoudNullData
+    {
+        short* sampleBuffer;
+        HANDLE audioProcessingDoneEvent;
+        Soloud *soloud;
+        unsigned int sampleCount;
+		unsigned int sampleRate;
+        Thread::ThreadHandle threadHandle;
+    };
+
+    static void nullThread(LPVOID aParam)
+    {
+        SoLoudNullData *data = static_cast<SoLoudNullData*>(aParam);
+
+		while (true)
+        {
+			float milliseconds = 1000.0f * data->sampleCount / data->sampleRate;
+			DWORD result = WaitForSingleObject(data->audioProcessingDoneEvent, milliseconds);
+
+			if (WAIT_TIMEOUT == result)
+			{
+				data->soloud->mixSigned16(data->sampleBuffer, data->sampleCount);
+			}
+			else
+			{
+				break;
+			}
+        }
+    }
+
     static void nullCleanup(Soloud *aSoloud)
     {
+        if (0 == aSoloud->mBackendData)
+        {
+            return;
+        }
+        SoLoudNullData *data = static_cast<SoLoudNullData*>(aSoloud->mBackendData);
+        SetEvent(data->audioProcessingDoneEvent);
+        if (data->threadHandle)
+		{
+			Thread::wait(data->threadHandle);
+			Thread::release(data->threadHandle);
+		}
+        if (0 != data->sampleBuffer)
+        {
+            delete[] data->sampleBuffer;
+        }
+        CloseHandle(data->audioProcessingDoneEvent);
+        delete data;
+        aSoloud->mBackendData = 0;
     }
 
     result null_init(Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer, unsigned int aChannels)
     {
 		if (aChannels == 0 || aChannels == 3 || aChannels == 5 || aChannels == 7 || aChannels > MAX_CHANNELS || aBuffer < SAMPLE_GRANULARITY)
 			return INVALID_PARAMETER;
-        aSoloud->mBackendData = 0;
-        aSoloud->mBackendCleanupFunc = nullCleanup;
 
+        SoLoudNullData *data = new SoLoudNullData;
+        ZeroMemory(data, sizeof(SoLoudNullData));
+        aSoloud->mBackendData = data;
+        aSoloud->mBackendCleanupFunc = nullCleanup;
+        data->sampleCount = aBuffer;
+		data->sampleRate = aSamplerate;
+        data->soloud = aSoloud;
+        data->audioProcessingDoneEvent = CreateEvent(0, FALSE, FALSE, 0);
+        if (0 == data->audioProcessingDoneEvent)
+        {
+            return UNKNOWN_ERROR;
+        }
+        data->sampleBuffer = new short[data->sampleRate * aChannels];
         aSoloud->postinit(aSamplerate, aBuffer, aFlags, aChannels);
+        data->threadHandle = Thread::createThread(nullThread, data);
+        if (0 == data->threadHandle)
+        {
+            return UNKNOWN_ERROR;
+        }
         aSoloud->mBackendString = "null driver";
         return SO_NO_ERROR;
     }

--- a/src/backend/null/soloud_null.cpp
+++ b/src/backend/null/soloud_null.cpp
@@ -37,6 +37,8 @@ namespace SoLoud
 
 #else
 
+#include <windows.h>
+
 namespace SoLoud
 {
     struct SoLoudNullData


### PR DESCRIPTION
I wrote a wasteful null driver backend in order to be able to run a game when there is no enabled audio devices. This null driver version just sleeps until the buffer is depleted and then wakes up to call mix again to advance time etc. Yes, it is wasteful. See issue #216 - this pretty much covers that.

I suppose you may want to differentiate between the old null driver and this one. But I did not dare to add another backend - I don't know what places should I touch. But the code is here for you to use for an initial version. Or I can make modifications to this one if I just knew what.

When it comes to automatic initialization of the backend with ::AUTO, I think it makes sense for this one to be automatically initialized. First, you *do* have to enable it in the first place with WITH_NULL (or whatever the name will be.) Second, it should the *last line* of defense, and if that fails, the whole soloud initialization will actually fail, and if the application code does not handle that, it will later crash when writing to an uninitialized buffer or something like that. So if the purpose of ::AUTO is to make using Soloud easy (but safe), then I'd go for automatic init.

By the way, I have not seen example code to deal with failed initialization robustly.