### PR TITLE
Change the order of WASAPI, XAudio2 and WinMM.

### DIFF
--- a/src/core/soloud.cpp
+++ b/src/core/soloud.cpp
@@ -307,6 +307,26 @@ namespace SoLoud
 		}
 #endif
 
+#if defined(WITH_WASAPI)
+		if (!inited &&
+			(aBackend == Soloud::WASAPI ||
+			aBackend == Soloud::AUTO))
+		{
+			if (aBufferSize == Soloud::AUTO) buffersize = 4096;
+			if (aSamplerate == Soloud::AUTO) samplerate = 48000;
+
+			int ret = wasapi_init(this, aFlags, samplerate, buffersize, aChannels);
+			if (ret == 0)
+			{
+				inited = 1;
+				mBackendID = Soloud::WASAPI;
+			}
+
+			if (ret != 0 && aBackend != Soloud::AUTO)
+				return ret;			
+		}
+#endif
+
 #if defined(WITH_XAUDIO2)
 		if (!inited &&
 			(aBackend == Soloud::XAUDIO2 ||
@@ -338,26 +358,6 @@ namespace SoLoud
 			{
 				inited = 1;
 				mBackendID = Soloud::WINMM;
-			}
-
-			if (ret != 0 && aBackend != Soloud::AUTO)
-				return ret;			
-		}
-#endif
-
-#if defined(WITH_WASAPI)
-		if (!inited &&
-			(aBackend == Soloud::WASAPI ||
-			aBackend == Soloud::AUTO))
-		{
-			if (aBufferSize == Soloud::AUTO) buffersize = 4096;
-			if (aSamplerate == Soloud::AUTO) samplerate = 48000;
-
-			int ret = wasapi_init(this, aFlags, samplerate, buffersize, aChannels);
-			if (ret == 0)
-			{
-				inited = 1;
-				mBackendID = Soloud::WASAPI;
 			}
 
 			if (ret != 0 && aBackend != Soloud::AUTO)


### PR DESCRIPTION
... to support automatic initialization of the backend better.

WASAPI is a lower level API than WinMM and XAudio2. On Windows,
both XAudio and WinMM internally use WASAPI. WASAPI supposedly
offers lower latency, and is included by default in all Windows versions
after XP - unlike XAudio2, which requires additional DLLs.

However, WASAPI does not offer any conversions when it comes
to buffers, making it a bit demanding to use from SoLoud. WinMM, on
the other hand converts merrily, and is included on all the same
modern platforms as is WASAPI.

Considering all of this, it makes sense to *first* try WASAPI,
and then the others if that fails.