### PR TITLE
Fix SDL include

### DIFF
--- a/src/backend/sdl2_static/soloud_sdl2_static.cpp
+++ b/src/backend/sdl2_static/soloud_sdl2_static.cpp
@@ -37,11 +37,7 @@ namespace SoLoud
 
 #else
 
-#if defined(_MSC_VER)
 #include <SDL.h>
-#else
-#include <SDL2/SDL.h>
-#endif
 #include <math.h>
 
 namespace SoLoud


### PR DESCRIPTION
Using SDL2/SDL.h make it impossible to build soLoud against the SDL source code (as the headers are in the include folder). The SDL2 part should be resolved at the build script level using search directory.
