### PR TITLE
C API: don't generate destroy() function for AudioAttenuator

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Tapio Vierros https://github.com/tapio
 Danny Angelo Carminati Grein https://github.com/fungos
 Igor Ivanov https://github.com/laptabrok
 Matthew O'Connell https://github.com/matthew-oconnell
+Daniel Ludwig https://github.com/code-disaster

--- a/include/soloud_c.h
+++ b/include/soloud_c.h
@@ -245,7 +245,6 @@ void Soloud_mixSigned16(Soloud * aSoloud, short * aBuffer, unsigned int aSamples
 /*
  * AudioAttenuator
  */
-void AudioAttenuator_destroy(AudioAttenuator * aAudioAttenuator);
 float AudioAttenuator_attenuate(AudioAttenuator * aAudioAttenuator, float aDistance, float aMinDistance, float aMaxDistance, float aRolloffFactor);
 
 /*

--- a/src/c_api/soloud.def
+++ b/src/c_api/soloud.def
@@ -105,7 +105,6 @@ EXPORTS
 	Soloud_set3dSourceDopplerFactor
 	Soloud_mix
 	Soloud_mixSigned16
-	AudioAttenuator_destroy
 	AudioAttenuator_attenuate
 	BassboostFilter_destroy
 	BassboostFilter_setParams

--- a/src/c_api/soloud_c.cpp
+++ b/src/c_api/soloud_c.cpp
@@ -694,11 +694,6 @@ void Soloud_mixSigned16(void * aClassPtr, short * aBuffer, unsigned int aSamples
 	cl->mixSigned16(aBuffer, aSamples);
 }
 
-void AudioAttenuator_destroy(void * aClassPtr)
-{
-  delete (AudioAttenuator *)aClassPtr;
-}
-
 float AudioAttenuator_attenuate(void * aClassPtr, float aDistance, float aMinDistance, float aMaxDistance, float aRolloffFactor)
 {
 	AudioAttenuator * cl = (AudioAttenuator *)aClassPtr;

--- a/src/tools/codegen/main.cpp
+++ b/src/tools/codegen/main.cpp
@@ -128,6 +128,12 @@ int is_banned(string aName)
 	return 0;
 }
 
+int is_interface(string aName)
+{	
+	if (aName == "AudioAttenuator") return 1;
+	return 0;
+}
+
 char * loadfile(const char *aFilename)
 {
 	FILE * f;
@@ -991,12 +997,15 @@ void generate()
 				" * %s\n"
 				" */\n",
 				gClass[i]->mName.c_str());
-			fprintf(f, "void %s_destroy(%s * a%s);\n", gClass[i]->mName.c_str(), gClass[i]->mName.c_str(), gClass[i]->mName.c_str());
-			fprintf(deff, "\t%s_destroy\n", gClass[i]->mName.c_str());
-			fprintf(pyff, "%s['void', '%s_destroy', [['%s *', 'a%s']]]", first?"":",\n", gClass[i]->mName.c_str(), gClass[i]->mName.c_str(), gClass[i]->mName.c_str());
+			if (!is_interface(gClass[i]->mName))
+			{
+				fprintf(f, "void %s_destroy(%s * a%s);\n", gClass[i]->mName.c_str(), gClass[i]->mName.c_str(), gClass[i]->mName.c_str());
+				fprintf(deff, "\t%s_destroy\n", gClass[i]->mName.c_str());
+				fprintf(pyff, "%s['void', '%s_destroy', [['%s *', 'a%s']]]", first?"":",\n", gClass[i]->mName.c_str(), gClass[i]->mName.c_str(), gClass[i]->mName.c_str());
+				emit_dtor(cppf, gClass[i]->mName.c_str());
+			}
 			first = 0;
-			emit_dtor(cppf, gClass[i]->mName.c_str());
-			
+
 			for (j = 0; j < (signed)gClass[i]->mMethod.size(); j++)
 			{
 				if (gClass[i]->mMethod[j]->mFuncName.find("Instance") == string::npos &&


### PR DESCRIPTION
When compiling the SoLoud C API on WSSL (Debian) with GCC 6.3.0, I see the following warning:

```
src/c_api/soloud_c.cpp: In function ‘void AudioAttenuator_destroy(void*)’:
src/c_api/soloud_c.cpp:699:29: warning: deleting object of abstract class type ‘SoLoud::AudioAttenuator’ which has non-virtual destructor will cause undefined behavior [-Wdelete-non-virtual-dtor]
   delete (AudioAttenuator *)aClassPtr;
                             ^~~~~~~~~
```

If I build with `-Wno-delete-non-virtual-dtor`, I get:

```
cc1: warning: command line option ‘-Wno-delete-non-virtual-dtor’ is valid for C++/ObjC++ but not for C
```

This PR changes the codegen to not generate the `AudioAttenuator_destroy()` function. I didn't dare to mess with the generator logic/parser, so there's a simple blacklist of classes, similar to `is_banned()`.
