### PR TITLE
Fix issues #232 and #233

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Tapio Vierros https://github.com/tapio
 Danny Angelo Carminati Grein https://github.com/fungos
 Igor Ivanov https://github.com/laptabrok
 Matthew O'Connell https://github.com/matthew-oconnell
+Boris Carvajal https://github.com/BorisCarvajal

--- a/include/soloud_c.h
+++ b/include/soloud_c.h
@@ -243,12 +243,6 @@ void Soloud_mix(Soloud * aSoloud, float * aBuffer, unsigned int aSamples);
 void Soloud_mixSigned16(Soloud * aSoloud, short * aBuffer, unsigned int aSamples);
 
 /*
- * AudioAttenuator
- */
-void AudioAttenuator_destroy(AudioAttenuator * aAudioAttenuator);
-float AudioAttenuator_attenuate(AudioAttenuator * aAudioAttenuator, float aDistance, float aMinDistance, float aMaxDistance, float aRolloffFactor);
-
-/*
  * BassboostFilter
  */
 void BassboostFilter_destroy(BassboostFilter * aBassboostFilter);

--- a/src/c_api/soloud.def
+++ b/src/c_api/soloud.def
@@ -105,8 +105,6 @@ EXPORTS
 	Soloud_set3dSourceDopplerFactor
 	Soloud_mix
 	Soloud_mixSigned16
-	AudioAttenuator_destroy
-	AudioAttenuator_attenuate
 	BassboostFilter_destroy
 	BassboostFilter_setParams
 	BassboostFilter_create

--- a/src/c_api/soloud_c.cpp
+++ b/src/c_api/soloud_c.cpp
@@ -694,17 +694,6 @@ void Soloud_mixSigned16(void * aClassPtr, short * aBuffer, unsigned int aSamples
 	cl->mixSigned16(aBuffer, aSamples);
 }
 
-void AudioAttenuator_destroy(void * aClassPtr)
-{
-  delete (AudioAttenuator *)aClassPtr;
-}
-
-float AudioAttenuator_attenuate(void * aClassPtr, float aDistance, float aMinDistance, float aMaxDistance, float aRolloffFactor)
-{
-	AudioAttenuator * cl = (AudioAttenuator *)aClassPtr;
-	return cl->attenuate(aDistance, aMinDistance, aMaxDistance, aRolloffFactor);
-}
-
 void BassboostFilter_destroy(void * aClassPtr)
 {
   delete (BassboostFilter *)aClassPtr;

--- a/src/tools/codegen/main.cpp
+++ b/src/tools/codegen/main.cpp
@@ -120,6 +120,7 @@ int is_banned(string aName)
 {	
 	if (aName.find("Instance") != string::npos) return 1;
 	if (aName == "AudioCollider") return 1;
+	if (aName == "AudioAttenuator") return 1;
 	if (aName == "Filter")  return 1;
 	if (aName == "AudioSource") return 1;
 	if (aName == "Fader") return 1;
@@ -1165,11 +1166,15 @@ void inherit_stuff()
 	}
 }
 
+#ifdef _MSC_VER
+  #define strcasecmp _stricmp
+#endif
+
 int main(int parc, char ** pars)
 {
 	printf(VERSION "\n");
 	
-	if (parc < 2 || _stricmp(pars[1], "go") != 0)
+	if (parc < 2 || strcasecmp(pars[1], "go") != 0)
 	{
 		printf("\nThis program will generate the 'C' api wrapper code.\n"
 			   "You probably ran this by mistake.\n"


### PR DESCRIPTION
Ban abstract AudioAttenuator class from codegen. Should supersede #230 pull.
Use _stricmp on MSVC, strcasecmp in other cases (this works on Mingw and POSIX systems).
