### PR TITLE
SDL Static function name fix

### DIFF
--- a/src/backend/sdl_static/soloud_sdl_static.cpp
+++ b/src/backend/sdl_static/soloud_sdl_static.cpp
@@ -29,7 +29,7 @@ freely, subject to the following restrictions:
 
 namespace SoLoud
 {
-	result sdlstatic_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer)
+	result sdl1static_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer)
 	{
 		return NOT_IMPLEMENTED;
 	}
@@ -57,7 +57,7 @@ namespace SoLoud
 		SDL_CloseAudio();
 	}
 
-	result sdlstatic_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer, unsigned int aChannels)
+	result sdl1static_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer, unsigned int aChannels)
 	{
 		SDL_AudioSpec as;
 		as.freq = aSamplerate;


### PR DESCRIPTION
Just fixing `sdlstatic_init` name to `sdl1static_init` in **soloud_sdl_static.cpp**
