### PR TITLE
Replace malloc.h with stdlib.h

### DIFF
--- a/src/audiosource/ay/chipplayer.cpp
+++ b/src/audiosource/ay/chipplayer.cpp
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <memory.h>
-#include <malloc.h>
 #include "chipplayer.h"
 #include "soloud_file.h"
 #include "soloud_ay.h"

--- a/src/audiosource/ay/sndbuffer.cpp
+++ b/src/audiosource/ay/sndbuffer.cpp
@@ -1,7 +1,7 @@
 #include "sndbuffer.h"
 #include "sndrender.h"
 
-#include "malloc.h"
+#include <stdlib.h>
 #include "memory.h"
 
 SNDBUFFER::SNDBUFFER(unsigned aSize) {


### PR DESCRIPTION
This should fix building with AppleClang since the current 10.15 sdk broke gcc! (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90835)

Also the malloc header is non-standard and also deprecated.