### PR TITLE
Fix macOS build: Replace malloc.h include with stdlib.h

### DIFF
--- a/src/audiosource/ay/chipplayer.cpp
+++ b/src/audiosource/ay/chipplayer.cpp
@@ -1,7 +1,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <memory.h>
-#include <malloc.h>
 #include "chipplayer.h"
 #include "soloud_file.h"
 #include "soloud_ay.h"

--- a/src/audiosource/ay/sndbuffer.cpp
+++ b/src/audiosource/ay/sndbuffer.cpp
@@ -1,7 +1,7 @@
 #include "sndbuffer.h"
 #include "sndrender.h"
 
-#include "malloc.h"
+#include <stdlib.h>
 #include "memory.h"
 
 SNDBUFFER::SNDBUFFER(unsigned aSize) {

--- a/src/audiosource/ay/sndbuffer.cpp
+++ b/src/audiosource/ay/sndbuffer.cpp
@@ -2,7 +2,7 @@
 #include "sndrender.h"
 
 #include <stdlib.h>
-#include "memory.h"
+#include <memory.h>
 
 SNDBUFFER::SNDBUFFER(unsigned aSize) {
         read_position = 0;


### PR DESCRIPTION
malloc.h is non-standard and doesn't exist on recent versions of macOS.

(Not adding name to AUTHORS file as this is trivial.)