### PR TITLE
docs: fix simple typo, dispoase -> dispose

### DIFF
--- a/demos/common/stb_image.h
+++ b/demos/common/stb_image.h
@@ -6359,7 +6359,7 @@ static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, i
       memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
       first_frame = 1; 
    } else {
-      // second frame - how do we dispoase of the previous one?
+      // second frame - how do we dispose of the previous one?
       dispose = (g->eflags & 0x1C) >> 2; 
       pcount = g->w * g->h; 
 


### PR DESCRIPTION
There is a small typo in demos/common/stb_image.h.

Should read `dispose` rather than `dispoase`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md