### PR TITLE
Use `aBuffer` parameter in `miniaudio_init`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Osman Turan https://osmanturan.com
 Samson Close https://github.com/qwertysam
 Bruce A Henderson https://github.com/woollybah
 Philip Bennefall https://github.com/blastbay/
+JackRedstonia jackredstonia64@gmail.com

--- a/src/backend/miniaudio/soloud_miniaudio.cpp
+++ b/src/backend/miniaudio/soloud_miniaudio.cpp
@@ -61,7 +61,7 @@ namespace SoLoud
     result miniaudio_init(SoLoud::Soloud *aSoloud, unsigned int aFlags, unsigned int aSamplerate, unsigned int aBuffer, unsigned int aChannels)
     {
         ma_device_config config = ma_device_config_init(ma_device_type_playback);
-        config.bufferSizeInFrames = 128;
+        config.bufferSizeInFrames = aBuffer;
         config.playback.format    = ma_format_f32;
         config.playback.channels  = aChannels;
         config.sampleRate         = aSamplerate;


### PR DESCRIPTION
This PR changes the `miniaudio_init` function to use the `aBuffer` parameter for configuring MiniAudio instead of a hard-coded value of `128`.