### PR TITLE
Use stb_vorbis_seek for seeking OGG sources

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Osman Turan https://osmanturan.com
 Samson Close https://github.com/qwertysam
 Bruce A Henderson https://github.com/woollybah
 Philip Bennefall https://github.com/blastbay/
+JackRedstonia jackredstonia64@gmail.com

--- a/include/soloud_wavstream.h
+++ b/include/soloud_wavstream.h
@@ -62,6 +62,7 @@ namespace SoLoud
 	public:
 		WavStreamInstance(WavStream *aParent);
 		virtual unsigned int getAudio(float *aBuffer, unsigned int aSamplesToRead, unsigned int aBufferSize);
+		virtual result seek(double aSeconds, float *mScratch, unsigned int mScratchSize);
 		virtual result rewind();
 		virtual bool hasEnded();
 		virtual ~WavStreamInstance();

--- a/src/audiosource/wav/soloud_wavstream.cpp
+++ b/src/audiosource/wav/soloud_wavstream.cpp
@@ -339,6 +339,24 @@ namespace SoLoud
 		}
 		return aSamplesToRead;
 	}
+	
+	result WavStreamInstance::seek(double aSeconds, float *mScratch, unsigned int mScratchSize)
+	{
+		if (mCodec.mOgg)
+		{
+			int sample_number = (int)floor(mSamplerate * aSeconds);
+			stb_vorbis_seek(mCodec.mOgg, sample_number);
+			// Since the position that we just seek to might not be *exactly*
+			// the position we returned, we're re-calculating the position just
+			// for the sake of correctness.
+			int new_sample_offset = stb_vorbis_get_sample_offset(mCodec.mOgg);
+			double new_position = float(new_sample_offset / mSamplerate);
+			mStreamTime = mStreamPosition = new_position;
+			return 0;
+		} else {
+			return AudioSourceInstance::seek(aSeconds, mScratch, mScratchSize);
+		}
+	}
 
 	result WavStreamInstance::rewind()
 	{


### PR DESCRIPTION
This PR adds `WavStreamInstance::seek` and uses `stb_vorbis_seek` if it is an OGG source. This partially addresses #156.