### PR TITLE
AudioSourceInstance::seek now sets stream position to input seconds.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -32,3 +32,4 @@ Osman Turan https://osmanturan.com
 Samson Close https://github.com/qwertysam
 Bruce A Henderson https://github.com/woollybah
 Philip Bennefall https://github.com/blastbay/
+David Bullock https://github.com/dwbullock

--- a/src/core/soloud_audiosource.cpp
+++ b/src/core/soloud_audiosource.cpp
@@ -176,7 +176,7 @@ namespace SoLoud
 			getAudio(mScratch, samples, samples);
 			samples_to_discard -= samples;
 		}
-		mStreamPosition = offset;
+		mStreamPosition = aSeconds;
 		return SO_NO_ERROR;
 	}
 


### PR DESCRIPTION
Fix: AudioSourceInstance::seek now sets stream position to input seconds.

Previously, AudioSourceInstance::seek would set the current position of the stream (mStreamPosition) to the offset calculated for the seek. This would work for streams that haven't started (offset will equal aSeconds) but not for streams that need to seek during playback.