### PR TITLE
[Incoming call on iPhone - no sound] fix

### DIFF
--- a/include/soloud.h
+++ b/include/soloud.h
@@ -106,6 +106,7 @@ namespace SoLoud
 	typedef void (*mutexCallFunction)(void *aMutexPtr);
 	typedef void (*soloudCallFunction)(Soloud *aSoloud);
 	typedef unsigned int result;
+	typedef result (*soloudResultFunction)(Soloud *aSoloud);
 	typedef unsigned int handle;
 	typedef double time;
 };
@@ -165,6 +166,10 @@ namespace SoLoud
 		// Called by SoLoud to shut down the back-end. If NULL, not called. Should be set by back-end.
 		soloudCallFunction mBackendCleanupFunc;
 
+		// Some backends like CoreAudio on iOS must be paused/resumed in some cases. On incoming call as instance.
+		soloudResultFunction mBackendPauseFunc;
+		soloudResultFunction mBackendResumeFunc;
+
 		// CTor
 		Soloud();
 		// DTor
@@ -223,6 +228,9 @@ namespace SoLoud
 
 		// Initialize SoLoud. Must be called before SoLoud can be used.
 		result init(unsigned int aFlags = Soloud::CLIP_ROUNDOFF, unsigned int aBackend = Soloud::AUTO, unsigned int aSamplerate = Soloud::AUTO, unsigned int aBufferSize = Soloud::AUTO, unsigned int aChannels = 2);
+
+		result pause();
+		result resume();
 
 		// Deinitialize SoLoud. Must be called before shutting down.
 		void deinit();

--- a/src/backend/coreaudio/soloud_coreaudio.cpp
+++ b/src/backend/coreaudio/soloud_coreaudio.cpp
@@ -55,7 +55,27 @@ namespace SoLoud
 		AudioQueueStop(audioQueue, true);
 		AudioQueueDispose(audioQueue, false);
 	}
+
+	result soloud_coreaudio_pause(SoLoud::Soloud *aSoloud)
+	{
+		if (!audioQueue)
+			return UNKNOWN_ERROR;
+
+		AudioQueuePause(audioQueue);			// TODO: Error code
+
+		return 0;
+	}
+
+	result soloud_coreaudio_resume(SoLoud::Soloud *aSoloud)
+	{
+		if (!audioQueue)
+			return UNKNOWN_ERROR;
 	
+		AudioQueueStart(audioQueue, nil);		// TODO: Error code
+
+		return 0;
+	}
+
 	static void coreaudio_mutex_lock(void *mutex)
 	{
 		Thread::lockMutex(mutex);
@@ -77,6 +97,8 @@ namespace SoLoud
 	{
 		aSoloud->postinit_internal(aSamplerate, aBuffer, aFlags, 2);
 		aSoloud->mBackendCleanupFunc = soloud_coreaudio_deinit;
+		aSoloud->mBackendPauseFunc = soloud_coreaudio_pause;
+		aSoloud->mBackendResumeFunc = soloud_coreaudio_resume;
 
 		AudioStreamBasicDescription audioFormat;
 		audioFormat.mSampleRate = aSamplerate;
@@ -122,6 +144,6 @@ namespace SoLoud
 
         aSoloud->mBackendString = "CoreAudio";
 		return 0;
-	}	
+	}
 };
 #endif

--- a/src/core/soloud.cpp
+++ b/src/core/soloud.cpp
@@ -116,6 +116,8 @@ namespace SoLoud
 		mAudioThreadMutex = NULL;
 		mPostClipScaler = 0;
 		mBackendCleanupFunc = NULL;
+		mBackendPauseFunc = NULL;
+		mBackendResumeFunc = NULL;
 		mChannels = 2;		
 		mStreamTime = 0;
 		mLastClockedTime = 0;
@@ -565,6 +567,23 @@ namespace SoLoud
 			return UNKNOWN_ERROR;
 		return 0;
 	}
+
+	result Soloud::pause()
+	{
+		if (mBackendPauseFunc)
+			return mBackendPauseFunc(this);
+
+		return NOT_IMPLEMENTED;
+	}
+
+	result Soloud::resume()
+	{
+		if (mBackendResumeFunc)
+			return mBackendResumeFunc(this);
+
+		return NOT_IMPLEMENTED;
+	}
+
 
 	void Soloud::postinit_internal(unsigned int aSamplerate, unsigned int aBufferSize, unsigned int aFlags, unsigned int aChannels)
 	{		


### PR DESCRIPTION
Added pause/resume methods in Soloud class.
Some backends like CoreAudio on iOS must be paused/resumed in some cases. On incoming call as instance.

Usage:
```
    AVAudioSession* session = [AVAudioSession sharedInstance];
    [session setCategory:AVAudioSessionCategoryAmbient error:nil];
    [session setActive:YES error:nil];

    // [[NSNotificationCenter defaultCenter] addObserver: self selector: @selector (routeChange :) name: AVAudioSessionRouteChangeNotification object: nil];
    [[NSNotificationCenter defaultCenter] addObserverForName: AVAudioSessionInterruptionNotification object: session queue: nil usingBlock: ^ (NSNotification * notification)
    {
        int status = [[notification.userInfo valueForKey: AVAudioSessionInterruptionTypeKey] intValue];
        if (status == AVAudioSessionInterruptionTypeBegan)
        {
            soloudInstance->pause();
        }
        else if (status == AVAudioSessionInterruptionTypeEnded)
        {
            [[AVAudioSession sharedInstance] setActive: TRUE error: nil];
            soloudInstance->resume();
        }
    }];
```
