### PR TITLE
Implement seek for missing codes in wavestream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Christian Rendina https://github.com/lakor64


### PR DESCRIPTION
The following code implements seeking for WAV, FLAC and MP3 on the . This also fixes looping on those three file types when enabled.

By looking on the offset code on OGG (with stb_vorbis_get_sample_offset), I am not sure if it's required on dr* libraries as it doesn't seem to jump to a different PCM, I guess stb_vorbis_get_sample_offsets gets the position that we seek?