### PR TITLE
Segfault in Soloud::stopVoice_internal fixed: mResampleDataOwner arra…

### DIFF
--- a/src/core/soloud.cpp
+++ b/src/core/soloud.cpp
@@ -164,7 +164,7 @@ namespace SoLoud
 		m3dVelocity[1] = 0;
 		m3dVelocity[2] = 0;		
 		m3dSoundSpeed = 343.3f;
-		mMaxActiveVoices = 16;
+		mMaxActiveVoices = 0;
 		mHighestVoice = 0;
 		mResampleData = NULL;
 		mResampleDataOwner = NULL;
@@ -599,6 +599,7 @@ namespace SoLoud
 		if (mScratchSize < 4096) mScratchSize = 4096;
 		mScratch.init(mScratchSize * MAX_CHANNELS);
 		mOutputScratch.init(mScratchSize * MAX_CHANNELS);
+		mMaxActiveVoices = 16;
 		mResampleData = new float*[mMaxActiveVoices * 2];
 		mResampleDataOwner = new AudioSourceInstance*[mMaxActiveVoices];
 		mResampleDataBuffer.init(mMaxActiveVoices * 2 * SAMPLE_GRANULARITY * MAX_CHANNELS);


### PR DESCRIPTION
…y size and mMaxActiveVoices was out of sync; this could happen when postinit_internal was not called
