### PR TITLE
Added a cmake option to disable the INSTALL target

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -41,3 +41,4 @@ Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
 Emilian Cioca https://github.com/EmilianC
+Kelly Gravelyn https://github.com/kellygravelyn

--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Emilian Cioca https://github.com/EmilianC

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -9,8 +9,6 @@ set (CMAKE_POSITION_INDEPENDENT_CODE ON)
 include_directories (../include)
 
 include (Configure.cmake)
-#INCLUDE (InstallIncludes.cmake)
-#INCLUDE (InstallStaticData.cmake)
 
 if (UNIX AND NOT WIN32 AND NOT APPLE)
 	if (CMAKE_SIZEOF_VOID_P MATCHES "8")
@@ -36,4 +34,6 @@ IF (SOLOUD_GENERATE_GLUE)
 	include (gen_glue.cmake)
 endif ()
 
-include (InstallExport)
+IF (SOLOUD_INSTALL)
+	include (InstallExport)
+endif ()

--- a/contrib/Configure.cmake
+++ b/contrib/Configure.cmake
@@ -7,6 +7,9 @@ print_option_status (SOLOUD_DYNAMIC "Build dynamic library")
 option (SOLOUD_STATIC "Set to ON to build static SoLoud" ON)
 print_option_status (SOLOUD_STATIC "Build static library")
 
+option (SOLOUD_INSTALL "Set to ON for generating an INSTALL target" ON)
+print_option_status (SOLOUD_INSTALL "Generate INSTALL target")
+
 option (SOLOUD_C_API "Set to ON to include the C API" OFF)
 print_option_status (SOLOUD_C_API "Build C API")
 

--- a/contrib/gen_glue.cmake
+++ b/contrib/gen_glue.cmake
@@ -22,7 +22,9 @@ add_custom_command (OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.cs"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/gen_cs.py"
         )
 add_custom_target (generate_glue_cs ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.cs")
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.cs" DESTINATION glue)
+if (SOLOUD_INSTALL)
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.cs" DESTINATION glue)
+endif ()
 
 ###############################################################################
 # Python API
@@ -33,7 +35,9 @@ add_custom_command (OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.rb"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/gen_ruby.py"
         )
 add_custom_target (generate_glue_ruby ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.rb")
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.rb" DESTINATION glue)
+if (SOLOUD_INSTALL)
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.rb" DESTINATION glue)
+endif ()
 
 ###############################################################################
 # Ruby API
@@ -44,4 +48,6 @@ add_custom_command (OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.py"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/gen_python.py"
         )
 add_custom_target(generate_glue_python ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.py")
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.py" DESTINATION glue)
+if (SOLOUD_INSTALL)
+        install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../glue/soloud.py" DESTINATION glue)
+endif ()

--- a/contrib/src.cmake
+++ b/contrib/src.cmake
@@ -165,13 +165,13 @@ if (SOLOUD_BACKEND_SDL2)
 
 endif()
 
-if (SOLOUD_BACKEND_ALSA)                     
-    add_definitions (-DWITH_ALSA)                
-                                           
-    set (BACKENDS_SOURCES              
-        ${BACKENDS_SOURCES} 
+if (SOLOUD_BACKEND_ALSA)
+    add_definitions (-DWITH_ALSA)
+
+    set (BACKENDS_SOURCES
+        ${BACKENDS_SOURCES}
         ${BACKENDS_PATH}/alsa/soloud_alsa.cpp
-    )                                              
+    )
 
     find_library (ALSA_LIBRARY asound)
     set (LINK_LIBRARIES
@@ -296,5 +296,7 @@ endif()
 
 target_link_libraries (${TARGET_NAME} ${LINK_LIBRARIES})
 
-include (Install)
-INSTALL(FILES ${TARGET_HEADERS} DESTINATION include/${TARGET_NAME})
+if (SOLOUD_INSTALL)
+	include (Install)
+	INSTALL(FILES ${TARGET_HEADERS} DESTINATION include/${TARGET_NAME})
+endif ()

--- a/include/soloud.h
+++ b/include/soloud.h
@@ -33,13 +33,10 @@ freely, subject to the following restrictions:
 #else
 #ifdef _MSC_VER
 #include <stdio.h> // for sprintf in asserts
-#ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN
-#endif
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h> // only needed for OutputDebugStringA, should be solved somehow.
+
+// Forward declare OutputDebugStringA to avoid including windows.h
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(char const* lpOutputString);
+
 #define SOLOUD_ASSERT(x) if (!(x)) { char temp[200]; sprintf(temp, "%s(%d): assert(%s) failed.\n", __FILE__, __LINE__, #x); OutputDebugStringA(temp); __debugbreak(); }
 #else
 #include <assert.h> // assert


### PR DESCRIPTION
This is useful for projects which don't support installing, allowing them to depend on soloud with less integration friction.
The default behavior of cmake generation is unchanged.