### PR TITLE
Add forward declaration for OutputDebugStringA

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Kelly Gravelyn https://github.com/kellygravelyn

--- a/include/soloud.h
+++ b/include/soloud.h
@@ -33,13 +33,10 @@ freely, subject to the following restrictions:
 #else
 #ifdef _MSC_VER
 #include <stdio.h> // for sprintf in asserts
-#ifndef VC_EXTRALEAN
-#define VC_EXTRALEAN
-#endif
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h> // only needed for OutputDebugStringA, should be solved somehow.
+
+// Forward declare OutputDebugStringA to avoid including windows.h
+extern "C" __declspec(dllimport) void __stdcall OutputDebugStringA(char const* lpOutputString);
+
 #define SOLOUD_ASSERT(x) if (!(x)) { char temp[200]; sprintf(temp, "%s(%d): assert(%s) failed.\n", __FILE__, __LINE__, #x); OutputDebugStringA(temp); __debugbreak(); }
 #else
 #include <assert.h> // assert


### PR DESCRIPTION
Should fix #330. I've used this forward declaration in my own games before to avoid bringing in windows.h before and it seems to build fine here.

I removed the extra #defines which I assume were only there to reduce what was brought in by windows.h but if they are necessary for some other functionality I can easily restore them.