### PR TITLE
Fix lutgen and sanity in non-windows environments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Beyley Thomas https://github.com/Beyley

--- a/src/tools/lutgen/main.cpp
+++ b/src/tools/lutgen/main.cpp
@@ -26,6 +26,10 @@ distribution.
 #include <string.h>
 #include <math.h>
 
+#ifndef _stricmp
+#define _stricmp strcasecmp
+#endif
+
 #define VERSION "SoLoud Lookup Table Generator (c)2015 Jari Komppa http://iki.fi/sol/"
 
 #define OUTDIR "../src/core/"

--- a/src/tools/sanity/sanity.cpp
+++ b/src/tools/sanity/sanity.cpp
@@ -100,7 +100,7 @@ long getmsec()
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 
-	return (ts->tv_sec * 1000) + (ts->tv_nsec / 1000000)
+	return (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
 }
 #endif
 


### PR DESCRIPTION
Previously lutgen used _stricmp always, even on non-windows. 
Now we alias it to strcasecmp if _stricmp is missing

And sanity's POSIX codepath previously was
 - trying to derefere a non-pointer
 - missing a semicolon

This makes the tools compile under linux using `zig cc` (clang-derived)