### PR TITLE
Fix comments for INAUDIBLE_KILL

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Adam Szabo https://github.com/proof88

--- a/include/soloud_audiosource.h
+++ b/include/soloud_audiosource.h
@@ -116,7 +116,7 @@ namespace SoLoud
 			LISTENER_RELATIVE = 16,
 			// Currently inaudible
 			INAUDIBLE = 32,
-			// If inaudible, should be killed (default = don't kill kill)
+			// If inaudible, should be killed (default = don't kill)
 			INAUDIBLE_KILL = 64,
 			// If inaudible, should still be ticked (default = pause)
 			INAUDIBLE_TICK = 128,
@@ -220,7 +220,7 @@ namespace SoLoud
 			LISTENER_RELATIVE = 16,
 			// Delay start of sound by the distance from listener
 			DISTANCE_DELAY = 32,
-			// If inaudible, should be killed (default)
+			// If inaudible, should be killed (default = don't kill)
 			INAUDIBLE_KILL = 64,
 			// If inaudible, should still be ticked (default = pause)
 			INAUDIBLE_TICK = 128,


### PR DESCRIPTION
The default inaudible behavior for AudioSource and AudioSourceInstance is NOT kill but pause, so I've just fixed the comments for INAUDIBLE_KILL.