### PR TITLE
Make Wav copy constructor and operator= private.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Yotam Gingold https://github.com/yig

--- a/include/soloud_wav.h
+++ b/include/soloud_wav.h
@@ -53,6 +53,9 @@ namespace SoLoud
 		result loadmp3(MemoryFile *aReader);
 		result loadflac(MemoryFile *aReader);
 		result testAndLoadFile(MemoryFile *aReader);
+		
+		Wav& operator=(const Wav&);
+		Wav(const Wav&);
 	public:
 		float *mData;
 		unsigned int mSampleCount;


### PR DESCRIPTION
I recommend that my students use soloud. They often accidentally "copy" a `SoLoud::Wav`. This prevents that.