### PR TITLE
Fix issues with WavStream looping (Flac, Wav & MP3)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Jake S. Del Mastro https://github.com/pgrAm

--- a/src/audiosource/wav/soloud_wavstream.cpp
+++ b/src/audiosource/wav/soloud_wavstream.cpp
@@ -258,7 +258,7 @@ namespace SoLoud
 					{
 						for (k = 0; k < mChannels; k++)
 						{
-							aBuffer[k * aSamplesToRead + i + j] = tmp[j * mCodec.mFlac->channels + k];
+							aBuffer[k * aBufferSize + i + j] = tmp[j * mCodec.mFlac->channels + k];
 						}
 					}
 				}
@@ -279,7 +279,7 @@ namespace SoLoud
 					{
 						for (k = 0; k < mChannels; k++)
 						{
-							aBuffer[k * aSamplesToRead + i + j] = tmp[j * mCodec.mMp3->channels + k];
+							aBuffer[k * aBufferSize + i + j] = tmp[j * mCodec.mMp3->channels + k];
 						}
 					}
 				}
@@ -327,7 +327,7 @@ namespace SoLoud
 					{
 						for (k = 0; k < mChannels; k++)
 						{
-							aBuffer[k * aSamplesToRead + i + j] = tmp[j * mCodec.mWav->channels + k];
+							aBuffer[k * aBufferSize + i + j] = tmp[j * mCodec.mWav->channels + k];
 						}
 					}
 				}
@@ -341,7 +341,7 @@ namespace SoLoud
 
 	result WavStreamInstance::seek(double aSeconds, float* mScratch, unsigned int mScratchSize)
 	{
-		if (mCodec.mOgg)
+		if (mParent->mFiletype == WAVSTREAM_OGG && mCodec.mOgg)
 		{
 			int pos = (int)floor(mBaseSamplerate * aSeconds);
 			stb_vorbis_seek(mCodec.mOgg, pos);
@@ -394,7 +394,7 @@ namespace SoLoud
 
 	bool WavStreamInstance::hasEnded()
 	{
-		if (mOffset >= mParent->mSampleCount)
+		if (!(mFlags & AudioSourceInstance::LOOPING) && mOffset >= mParent->mSampleCount)
 		{
 			return 1;
 		}


### PR DESCRIPTION
There were a few issues with WavStreams and looping, fixed here

- WavStreamInstance::seek would always take the branch for OGG leading other formats to stop playing after one loop
- The sample copying loop was using the incorrect pitch, aSamplesToRead instead of aBufferSize, causing garbage noise at the end of a loop when aSamplesToRead  != aBufferSize
- logic for WavStreamInstance::hasEnded() differed from that of WavInstance::hasEnded()