### PR TITLE
Fix unused value warning

### DIFF
--- a/src/audiosource/speech/klatt.cpp
+++ b/src/audiosource/speech/klatt.cpp
@@ -97,7 +97,7 @@ enum ELEMENTS
 
 #define PHONEME_COUNT 53
 #define AMP_ADJ 14
-#define StressDur(e,s) (s,((e->mDU + e->mUD)/2))
+#define StressDur(e,s) ((void)s,((e->mDU + e->mUD)/2))
 
 
 


### PR DESCRIPTION
My poor little compiler didn't like the use of the StressDur macro:

```
soloud/src/audiosource/speech/klatt.cpp:762:33: warning: left operand of comma operator has no effect [-Wunused-value]
  762 |                                 int stressdur = StressDur(p,stress);

```
Easy enough fix.