### PR TITLE
Add Missing `asound` Link to SoloudDynamic #309

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,4 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Aeva Palecek https://zone.dog/

--- a/build/genie.lua
+++ b/build/genie.lua
@@ -954,6 +954,9 @@ end
 		}
 
 		links {"SoloudStatic"}
+if (WITH_ALSA == 1) then
+		links {"asound"}
+end
 
 if (os.is("Windows")) then
 	linkoptions { "/DEF:\"../../src/c_api/soloud.def\"" }


### PR DESCRIPTION
This change resolves #309.  Prior to this change, the soloud .so file on Linux was built without linking alsa (when alsa is selected), which prevents dynamic linking from being useful.  This change adds the missing link declaration to genie.lua.

Per the contributor guidelines, I have added my name to the `AUTHORS` file to confirm that I have read, understand, and accept the rules outlined in the `PULL_REQUEST_TEMPLATE.md` and `CONTRIBUTING` files, however I do not think this contribution merits an entry in the `AUTHORS` list.
