### PR TITLE
Increase CMake minimum version to comply with CMake 4.0

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.10)
 
 project (SoLoud)
 


### PR DESCRIPTION
CMake 4.0 increases the minimum acceptable version to 3.5 and will warn for anything below 3.10.  This change both fixes a failing CMake configure (which would also work with 3.5) but increases it directly to 3.10 to remove the deprecation warning as well