### PR TITLE
Fix compile error in dr_mp3.h for Windows on ARM

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -40,3 +40,5 @@ lexander Yashin https://github.com/yashin-alexander
 Nils Duval https://github.com/nlsdvl
 JackRedstonia jackredstonia64@gmail.com
 David Bullock https://github.com/dwbullock
+Alexander Bock https://github.com/alexanderbock
+

--- a/src/audiosource/wav/dr_mp3.h
+++ b/src/audiosource/wav/dr_mp3.h
@@ -2103,7 +2103,8 @@ static void drmp3d_synth(float *xl, drmp3d_sample_t *dstl, int nch, float *lins)
             vst1_lane_s16(dstl + (49 + i)*nch, pcmb, 2);
 #endif
 #else
-            static const drmp3_f4 g_scale = { 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f, 1.0f/32768.0f };
+            static const drmp3_f4 initv[4] = { 1.0f / 32768.0f, 1.0f / 32768.0f, 1.0f / 32768.0f, 1.0f / 32768.0f };
+            static const drmp3_f4 g_scale = vld1q_f32(initv);
             a = DRMP3_VMUL(a, g_scale);
             b = DRMP3_VMUL(b, g_scale);
 #if DRMP3_HAVE_SSE


### PR DESCRIPTION
In the MSVC implementation of ARM Neon, the `float32x4_t` intrinsic is a union type that cannot be initialized using initializer lists.
It was supposed to be fixed a while ago (https://developercommunity.visualstudio.com/t/static-initialization-arm64-neon-datatypes/1238406) but is not on Visual Studio 17.14.13 and the current code results in a compile error. 

Code for the intrinsic initialization based on constant values from:
https://developer.arm.com/documentation/102581/0200/Porting-intrinsics

All rights to this patch are released to the project owner.
