### PR TITLE
Compiler warnings

### DIFF
--- a/include/soloud_file.h
+++ b/include/soloud_file.h
@@ -46,6 +46,17 @@ namespace SoLoud
 		virtual unsigned int pos() = 0;
 		virtual FILE * getFilePtr() { return 0; }
 		virtual const unsigned char * getMemPtr() { return 0; }
+
+		bool read4ByteHeader(const char* header) {
+			unsigned int i = this->read32();
+			const unsigned char* pI = (const unsigned char*)(&i);
+			const unsigned char* pH = (const unsigned char*)header;
+			return (pI[0] == pH[0]
+				&& pI[1] == pH[1]
+				&& pI[2] == pH[2]
+				&& pI[3] == pH[3]
+				);
+		}
 	};
 
 	class DiskFile : public File

--- a/include/zx7decompress.h
+++ b/include/zx7decompress.h
@@ -1,7 +1,7 @@
 /*
  * zx7 decompress by Jari Komppa, under public domain / unlicense
  *
- * Heavily based on zx7 decompressor by Einar Saukas. 
+ * Heavily based on zx7 decompressor by Einar Saukas.
  * Einar Saukas requests that you mention the use of dx7, but
  * this is not enforced by any way.
  *
@@ -15,98 +15,97 @@
 extern "C" {
 #endif
 
-struct zx7_io
-{
-    unsigned char* input_data;
-    unsigned char* output_data;
-    size_t input_index;
-    size_t output_index;
-    int bit_mask;
-    int bit_value;
-};
+    struct zx7_io {
+        unsigned char* input_data;
+        unsigned char* output_data;
+        size_t input_index;
+        size_t output_index;
+        int bit_mask;
+        int bit_value;
+    };
 
-static int zx7_read_byte(struct zx7_io *io) {
-    return io->input_data[io->input_index++];
-}
-
-static int zx7_read_bit(struct zx7_io *io) {
-    io->bit_mask >>= 1;
-    if (io->bit_mask == 0) {
-        io->bit_mask = 128;
-        io->bit_value = zx7_read_byte(io);
+    static int zx7_read_byte(struct zx7_io* io) {
+        return io->input_data[io->input_index++];
     }
-    return io->bit_value & io->bit_mask ? 1 : 0;
-}
 
-static int zx7_read_elias_gamma(struct zx7_io *io) {
-    int i = 0;
-    int value = 0;
-
-    while (!zx7_read_bit(io)) {
-        i++;
+    static int zx7_read_bit(struct zx7_io* io) {
+        io->bit_mask >>= 1;
+        if (io->bit_mask == 0) {
+            io->bit_mask = 128;
+            io->bit_value = zx7_read_byte(io);
+        }
+        return io->bit_value & io->bit_mask ? 1 : 0;
     }
-    if (i > 15) {
-        return -1;
-    }
-    value = 1;
-    while (i--) {
-        value = value << 1 | zx7_read_bit(io);
-    }
-    return value;
-}
 
-static int zx7_read_offset(struct zx7_io *io) {
-    int value = 0;
-    int i = 0;
+    static int zx7_read_elias_gamma(struct zx7_io* io) {
+        int i = 0;
+        int value = 0;
 
-    value = zx7_read_byte(io);
-    if (value < 128) {
+        while (!zx7_read_bit(io)) {
+            i++;
+        }
+        if (i > 15) {
+            return -1;
+        }
+        value = 1;
+        while (i--) {
+            value = value << 1 | zx7_read_bit(io);
+        }
         return value;
-    } else {
-        i = zx7_read_bit(io);
-        i = i << 1 | zx7_read_bit(io);
-        i = i << 1 | zx7_read_bit(io);
-        i = i << 1 | zx7_read_bit(io);
-        return (value & 127 | i << 7) + 128;
     }
-}
 
-static void zx7_write_byte(struct zx7_io *io, int value) {
-    io->output_data[io->output_index++] = value;
-}
+    static int zx7_read_offset(struct zx7_io* io) {
+        int value = 0;
+        int i = 0;
 
-static void zx7_write_bytes(struct zx7_io *io, int offset, int length) {
-    int i;
-    while (length-- > 0) {
-        i = io->output_index - offset;
-        zx7_write_byte(io, io->output_data[i]);
-    }
-}
-
-static int zx7_decompress(unsigned char *input_data, unsigned char *output_data) {
-    struct zx7_io io;
-    int length;
-
-    io.input_data = input_data;
-    io.output_data = output_data;
-    io.input_index = 0;
-    io.output_index = 0;
-    io.bit_mask = 0;
-    io.bit_value = 0;
-
-    zx7_write_byte(&io, zx7_read_byte(&io));
-    while (1) {
-        if (!zx7_read_bit(&io)) {
-            zx7_write_byte(&io, zx7_read_byte(&io));
+        value = zx7_read_byte(io);
+        if (value < 128) {
+            return value;
         } else {
-            length = zx7_read_elias_gamma(&io) + 1;
-            if (length == 0) {
-                return io.input_index;
-            }
-            zx7_write_bytes(&io, zx7_read_offset(&io) + 1, length);
+            i = zx7_read_bit(io);
+            i = i << 1 | zx7_read_bit(io);
+            i = i << 1 | zx7_read_bit(io);
+            i = i << 1 | zx7_read_bit(io);
+            return (value & 127 | i << 7) + 128;
         }
     }
-}
+
+    static void zx7_write_byte(struct zx7_io* io, int value) {
+        io->output_data[io->output_index++] = value;
+    }
+
+    static void zx7_write_bytes(struct zx7_io* io, int offset, int length) {
+        size_t i;
+        while (length-- > 0) {
+            i = io->output_index - offset;
+            zx7_write_byte(io, io->output_data[i]);
+        }
+    }
+
+    static int zx7_decompress(unsigned char* input_data, unsigned char* output_data) {
+        struct zx7_io io;
+        int length;
+
+        io.input_data = input_data;
+        io.output_data = output_data;
+        io.input_index = 0;
+        io.output_index = 0;
+        io.bit_mask = 0;
+        io.bit_value = 0;
+
+        zx7_write_byte(&io, zx7_read_byte(&io));
+        while (1) {
+            if (!zx7_read_bit(&io)) {
+                zx7_write_byte(&io, zx7_read_byte(&io));
+            } else {
+                length = zx7_read_elias_gamma(&io) + 1;
+                if (length == 0) {
+                    return int(io.input_index);
+                }
+                zx7_write_bytes(&io, zx7_read_offset(&io) + 1, length);
+            }
+        }
+    }
 
 #ifdef __cplusplus
 }

--- a/src/audiosource/ay/soloud_ay.cpp
+++ b/src/audiosource/ay/soloud_ay.cpp
@@ -134,8 +134,10 @@ namespace SoLoud
 		if (aFile->length() < 34) return FILE_LOAD_FAILED;
 
 		aFile->seek(0);
-		if (aFile->read32() != 'PIHC') return FILE_LOAD_FAILED; // CHIP
-		if (aFile->read32() != 'ENUT') return FILE_LOAD_FAILED; // TUNE
+		// if (aFile->read32() != 'PIHC') return FILE_LOAD_FAILED; // CHIP
+		// if (aFile->read32() != 'ENUT') return FILE_LOAD_FAILED; // TUNE
+		if (aFile->read4ByteHeader("CHIP")) return FILE_LOAD_FAILED; // CHIP
+		if (aFile->read4ByteHeader("TUNE")) return FILE_LOAD_FAILED; // TUNE
 		int dataofs = aFile->read16();
 		int chiptype = aFile->read8();
 		// check if this file is for AY / YM, turbosound or turbosound next

--- a/src/audiosource/speech/klatt.cpp
+++ b/src/audiosource/speech/klatt.cpp
@@ -97,7 +97,7 @@ enum ELEMENTS
 
 #define PHONEME_COUNT 53
 #define AMP_ADJ 14
-#define StressDur(e,s) (s,((e->mDU + e->mUD)/2))
+//#define StressDur(e,s) (s,((e->mDU + e->mUD)/2))
 
 
 
@@ -759,7 +759,9 @@ int klatt::phone_to_elm(char *aPhoneme, int aCount, darray *aElement)
 				if (!(p->mFeat & ELM_FEATURE_VWL))
 					stress = 0;
 
-				int stressdur = StressDur(p,stress);
+			    // #define StressDur(e,s) (s,((e->mDU + e->mUD)/2))
+				// int stressdur = StressDur(p,stress);
+				int stressdur = (p->mDU + p->mUD)/2;
 
 				t += stressdur;
 

--- a/src/audiosource/tedsid/soloud_tedsid.cpp
+++ b/src/audiosource/tedsid/soloud_tedsid.cpp
@@ -163,6 +163,7 @@ namespace SoLoud
 		return res;
 	}
 
+
 	result TedSid::loadFile(File *aFile)
 	{
 		if (aFile == NULL)
@@ -173,8 +174,10 @@ namespace SoLoud
 		if (aFile->length() < 34) return FILE_LOAD_FAILED;
 
 		aFile->seek(0);
-		if (aFile->read32() != 'PIHC') return FILE_LOAD_FAILED; // CHIP
-		if (aFile->read32() != 'ENUT') return FILE_LOAD_FAILED; // TUNE
+		// if (aFile->read32() != 'PIHC') return FILE_LOAD_FAILED; // CHIP
+		// if (aFile->read32() != 'ENUT') return FILE_LOAD_FAILED; // TUNE
+		if (aFile->read4ByteHeader("CHIP")) return FILE_LOAD_FAILED; // CHIP
+		if (aFile->read4ByteHeader("TUNE")) return FILE_LOAD_FAILED; // TUNE
 		int dataofs = aFile->read16();
 		int chiptype = aFile->read8();
 		// check if this file is for sid, ted, or combination of several

--- a/src/audiosource/wav/stb_vorbis.c
+++ b/src/audiosource/wav/stb_vorbis.c
@@ -1403,7 +1403,8 @@ static int set_file_offset(stb_vorbis *f, unsigned int loc)
    #endif
    f->eof = 0;
    if (USE_MEMORY(f)) {
-      if (f->stream_start + loc >= f->stream_end || f->stream_start + loc < f->stream_start) {
+      //                                                               vVv no sense for unsigned
+      if (f->stream_start + loc >= f->stream_end || f->stream_start + (int)loc < f->stream_start) {
          f->stream = f->stream_end;
          f->eof = 1;
          return 0;


### PR DESCRIPTION
I just made some adjustments to code that did compile, but some compilers gave warnings.
```
// if (aFile->read32() != 'PIHC') return FILE_LOAD_FAILED; // CHIP
```
and commented
```
int stressdur = StressDur(p,stress);
```
because it was never used, anyway.
Unfortunately, Clangformat did a lot of reformating :(